### PR TITLE
refactor: clean up next pages rendering

### DIFF
--- a/components/articlehero.tsx
+++ b/components/articlehero.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Image from "next/image";
 import { WorkInfo } from "../global/content";
 
 interface ArticleHeroProps {
@@ -15,7 +16,16 @@ const ArticleHero = (props: ArticleHeroProps) => (
     <div className="container">
       {props.image && (
         <div className="hero" style={{ backgroundColor: props.bgColor }}>
-          <img src={props.image} alt={props.title} style={props.customImageStyle} />
+          <Image
+            src={props.image}
+            alt={props.title}
+            width={1600}
+            height={900}
+            priority
+            sizes="100vw"
+            className="heroImage"
+            style={props.customImageStyle}
+          />
         </div>
       )}
       {!props.image && <div className="spacer" />}
@@ -75,7 +85,7 @@ const ArticleHero = (props: ArticleHeroProps) => (
         width: 100vw;
         margin-top: 64px;
       }
-      img {
+      .heroImage {
         height: 100%;
         width: auto;
       }

--- a/components/articleimage.tsx
+++ b/components/articleimage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Image from "next/image";
 
 interface ArticleImageProps {
   image?: string;
@@ -46,10 +47,26 @@ const ArticleImage = (props: ArticleImageProps) => {
   return (
     <div className="container">
       <div className="image">
-        {!props.zoomable && <img src={image} alt={alt} />}
+        {!props.zoomable && (
+          <Image
+            className="articleImage"
+            src={image}
+            alt={alt}
+            width={1024}
+            height={430}
+            sizes="(max-width: 1024px) calc(100vw - 32px), 1024px"
+          />
+        )}
         {props.zoomable && (
           <a href={image} target="_blank" rel="noreferrer">
-            <img src={image} alt={alt} />
+            <Image
+              className="articleImage"
+              src={image}
+              alt={alt}
+              width={1024}
+              height={430}
+              sizes="(max-width: 1024px) calc(100vw - 32px), 1024px"
+            />
           </a>
         )}
       </div>
@@ -66,8 +83,9 @@ const ArticleImage = (props: ArticleImageProps) => {
           height: 100%;
           overflow: hidden;
         }
-        img {
+        .articleImage {
           width: 100%;
+          height: auto;
         }
 
         @media only screen and (max-width: 1024px) {

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from "react";
+import Image from "next/image";
 import Icon from "../components/icon";
 import { animated, useSpring } from "@react-spring/web";
 
@@ -52,6 +53,7 @@ const Card = (props: CardProps) => {
                   key={(props.href ?? "") + layer + i}
                 >
                   <animated.div
+                    className="imageLayer"
                     style={{
                       transform: transform
                         ? transform.xyzs.to((...args: number[]) => {
@@ -61,7 +63,16 @@ const Card = (props: CardProps) => {
                         : "",
                     }}
                   >
-                    {layer && <img className="cardImage" src={layer} alt="" />}
+                    {layer && (
+                      <Image
+                        className="cardImage"
+                        src={layer}
+                        alt=""
+                        aria-hidden="true"
+                        fill
+                        sizes="(max-width: 425px) 100vw, (max-width: 1024px) 50vw, 512px"
+                      />
+                    )}
                   </animated.div>
                 </div>
               ))}
@@ -126,13 +137,18 @@ const Card = (props: CardProps) => {
         }
         .imageContainer {
           position: relative;
+          width: 100%;
+          height: 100%;
         }
-        .layerContainer {
+        .layerContainer,
+        .imageLayer {
           position: absolute;
+          width: 100%;
+          height: 100%;
           top: 0;
           left: 0;
         }
-        img {
+        .cardImage {
           width: 100%;
           height: 100%;
           top: 0;

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -11,6 +11,20 @@ const PERSPECTIVE = 1300;
 const SPRING_DAMPENER = 75;
 const SCALE = 1.022;
 
+const normalizeLocalImageSrc = (src: string) => {
+  if (
+    !src ||
+    src.startsWith("/") ||
+    src.startsWith("http://") ||
+    src.startsWith("https://") ||
+    src.startsWith("data:")
+  ) {
+    return src;
+  }
+
+  return `/${src}`;
+};
+
 const getParallaxStyle = (x: number, y: number, z: number, i: number) => {
   const p = PARALLAX_OFFSET + z * i * PARALLAX_MULTIPLIER;
   const xt = Math.sin(y * PARALLAX_SPRING_FACTOR) * p * PARALLAX_TRANSLATION_FACTOR;
@@ -66,7 +80,7 @@ const Card = (props: CardProps) => {
                     {layer && (
                       <Image
                         className="cardImage"
-                        src={layer}
+                        src={normalizeLocalImageSrc(layer)}
                         alt=""
                         aria-hidden="true"
                         fill

--- a/global/site.ts
+++ b/global/site.ts
@@ -1,0 +1,12 @@
+export const siteMetadata = {
+  title: "Donovan Yohan - UI/UX Designer & Web Developer",
+  description: "Hi, I'm Donovan Yohan! I'm a UI & UX designer and a full stack developer.",
+  url: "https://donovanyohan.com",
+  ogImagePath: "/ogimage.jpg",
+  themeColor: "#FFFFFF",
+};
+
+export const getAbsoluteSiteUrl = (path = "") => {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${siteMetadata.url}${normalizedPath}`;
+};

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -4,6 +4,7 @@ import Nav from "../components/nav";
 import Footer from "../components/footer";
 import BottomNav from "../components/bottomNav";
 import { MobileWidth } from "../global/global";
+import { getAbsoluteSiteUrl, siteMetadata } from "../global/site";
 import useSmoothScroll from "../hooks/useSmoothScroll";
 import useWindowWidth from "../hooks/useWindowWidth";
 
@@ -50,27 +51,19 @@ const Main = (props: MainProps) => {
   return (
     <div>
       <Head>
-        <title>Donovan Yohan - UI/UX Designer &amp; Web Developer</title>
-        <meta
-          name="description"
-          content="Hi, I'm Donovan Yohan! I'm a UI & UX designer and a full stack developer."
-        />
-        <meta name="theme-color" content="#FFFFFF" />
-        <meta
-          key="og:title"
-          property="og:title"
-          content="Donovan Yohan - UI/UX Designer & Web Developer"
-        />
-        <meta
-          key="og:description"
-          property="og:description"
-          content="Hi, I'm Donovan Yohan! I'm a UI & UX designer and a full stack developer."
-        />
+        <title>{siteMetadata.title}</title>
+        <meta name="description" content={siteMetadata.description} />
+        <meta name="theme-color" content={siteMetadata.themeColor} />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta key="og:title" property="og:title" content={siteMetadata.title} />
+        <meta key="og:description" property="og:description" content={siteMetadata.description} />
         <meta
           key="og:image"
           property="og:image"
-          content="https://donovanyohan.donovanyohan.now.sh/ogimage.jpg"
+          content={getAbsoluteSiteUrl(siteMetadata.ogImagePath)}
         />
+        <meta key="og:url" property="og:url" content={siteMetadata.url} />
+        <meta key="twitter:card" name="twitter:card" content="summary_large_image" />
       </Head>
       <Nav breadcrumbs={props.breadcrumbs} isPhone={windowWidth !== null && windowWidth <= 425} />
       {props.children}

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import Nav from "../components/nav";
 import Footer from "../components/footer";
 import BottomNav from "../components/bottomNav";
@@ -45,8 +46,11 @@ const cssDarkVars: Record<string, string> = {
 };
 
 const Main = (props: MainProps) => {
+  const router = useRouter();
   const windowWidth = useWindowWidth();
   useSmoothScroll();
+  const currentPath = router.asPath.split(/[?#]/)[0] || "/";
+  const canonicalUrl = getAbsoluteSiteUrl(currentPath);
 
   return (
     <div>
@@ -62,7 +66,7 @@ const Main = (props: MainProps) => {
           property="og:image"
           content={getAbsoluteSiteUrl(siteMetadata.ogImagePath)}
         />
-        <meta key="og:url" property="og:url" content={siteMetadata.url} />
+        <meta key="og:url" property="og:url" content={canonicalUrl} />
         <meta key="twitter:card" name="twitter:card" content="summary_large_image" />
       </Head>
       <Nav breadcrumbs={props.breadcrumbs} isPhone={windowWidth !== null && windowWidth <= 425} />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -2,9 +2,11 @@ import { Html, Head, Main, NextScript } from "next/document";
 
 export default function MyDocument() {
   return (
-    <Html>
+    <Html lang="en">
       <Head>
         <link rel="icon" href="/favicon.ico" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
           href="https://fonts.googleapis.com/css?family=Open+Sans:300,400|Roboto:400,700&display=swap"
           rel="stylesheet"

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Hero from "../components/hero";
 import Card from "../components/card";
 import { MobileWidth, hobbies } from "../global/global";
@@ -13,7 +14,17 @@ const About = () => {
       <div className="pageRoot">
         <div className="pageContent">
           <Hero
-            image={<img src="img/photos/about.jpg" className="heroImage" alt="About Donovan" />}
+            image={
+              <Image
+                src="/img/photos/about.jpg"
+                width={420}
+                height={420}
+                priority
+                className="heroImage"
+                alt="About Donovan"
+                sizes="(max-width: 450px) 66vw, (max-width: 1130px) 47vw, 420px"
+              />
+            }
             text={AboutHero}
             customImageStyle={{ margin: "0px" }}
           />

--- a/test/design-system-smoke.test.ts
+++ b/test/design-system-smoke.test.ts
@@ -4,6 +4,32 @@ import { shopdonovanyohanInfo } from "../global/content";
 import links, { projects, socialLinks, MobileWidth } from "../global/global";
 import { getAbsoluteSiteUrl, siteMetadata } from "../global/site";
 
+describe("article image src normalization", () => {
+  it("keeps valid image src values and normalizes public img paths", () => {
+    expect(normalizeArticleImageSrc("/img/photos/work/dy-problem.png")).toBe(
+      "/img/photos/work/dy-problem.png"
+    );
+    expect(normalizeArticleImageSrc("img/photos/work/dy-problem.png")).toBe(
+      "/img/photos/work/dy-problem.png"
+    );
+    expect(normalizeArticleImageSrc("https://example.com/image.png")).toBe(
+      "https://example.com/image.png"
+    );
+    expect(normalizeArticleImageSrc("data:image/png;base64,abc")).toBe("data:image/png;base64,abc");
+    expect(normalizeArticleImageSrc("blob:https://example.com/image-id")).toBe(
+      "blob:https://example.com/image-id"
+    );
+  });
+
+  it("rejects empty, placeholder, and non-public relative image src values", () => {
+    expect(normalizeArticleImageSrc()).toBeNull();
+    expect(normalizeArticleImageSrc("")).toBeNull();
+    expect(normalizeArticleImageSrc("src")).toBeNull();
+    expect(normalizeArticleImageSrc("SRC")).toBeNull();
+    expect(normalizeArticleImageSrc("photos/work/example.png")).toBeNull();
+  });
+});
+
 describe("portfolio data smoke test", () => {
   it("keeps navigation and project content available", () => {
     expect(links.length).toBeGreaterThan(0);

--- a/test/design-system-smoke.test.ts
+++ b/test/design-system-smoke.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { normalizeArticleImageSrc } from "../components/articleimage";
 import { shopdonovanyohanInfo } from "../global/content";
 import links, { projects, socialLinks, MobileWidth } from "../global/global";
+import { getAbsoluteSiteUrl, siteMetadata } from "../global/site";
 
 describe("portfolio data smoke test", () => {
   it("keeps navigation and project content available", () => {
@@ -9,6 +10,10 @@ describe("portfolio data smoke test", () => {
     expect(socialLinks.length).toBeGreaterThan(0);
     expect(projects.some((project) => project.label === "donovanyohan.com")).toBe(true);
     expect(MobileWidth).toBe(1024);
+    expect(siteMetadata.url).toBe("https://donovanyohan.com");
+    expect(getAbsoluteSiteUrl(siteMetadata.ogImagePath)).toBe(
+      "https://donovanyohan.com/ogimage.jpg"
+    );
   });
 
   it("keeps icon font glyphs on nav and social links", () => {


### PR DESCRIPTION
## Summary
- Moves portfolio article/card/about imagery that has stable local assets onto `next/image` without changing the Pages Router structure or visual design.
- Centralizes the shared site title/description/OG URL in `global/site.ts` and updates the stale `now.sh` OG image URL to `https://donovanyohan.com/ogimage.jpg`.
- Adds document-level `lang="en"` and Google Fonts preconnect hints while keeping the existing Open Sans/Roboto visual language intact.

## Stack
- Base: `feat/design-system-tooling` (PR #27)
- Head: `feat/next-cleanup`
- This is intentionally still Pages Router. No App Router migration, design-system primitives, or dot-grid work is included.

## Verification
- `npm run format:check`
- `npm run check` (lint, typecheck, Vitest, production Next build)
- Local production smoke test on port 3127:
  - `/` contains `Donovan Yohan`, `UI & UX designer`, and `https://donovanyohan.com/ogimage.jpg`
  - `/about` contains `About me.`, `About Donovan`, and the optimized about image URL
  - `/work/donovanyohan` contains `donovanyohan.com` and the optimized banner image URL

## The Case Against
- This PR uses conservative width/height hints for dynamic local images because the source components receive image paths as strings rather than imported static assets. If exact intrinsic dimensions become important, the next cleanup step should move image metadata into structured content data instead of hardcoding per-component defaults.
- Gallery images on the graphic-design page are deliberately left as raw `<img>` elements for now because they have varied artwork ratios and layout widths; forcing them through `next/image` in this slice would increase visual-regression risk.
- Updating the OG URL assumes `donovanyohan.com` is the canonical production domain, matching existing content links in the repo.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Optimized images shift layout | Preserved existing wrappers/CSS and smoke-tested key pages against the production server. |
| Pages Router modernization expands into redesign | Scope is limited to image/head metadata cleanup; no layout primitives or dot-grid implementation. |
| Stacked branch review confusion | PR targets `feat/design-system-tooling` and states the base/head explicitly. |
