### PR TITLE
fix: restore portfolio card images

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -102,27 +102,18 @@ const Card = (props: CardProps) => {
             </div>
           </div>
           {!props.disabled &&
-            !props.isExternal &&
             (isNestedInCardLink ? (
               <span className="mobileButton">
                 <span>Learn More</span>
                 <Icon icon="" size="small" />
               </span>
             ) : (
-              <a href={props.href} className="mobileButton">
-                <span>Learn More</span>
-                <Icon icon="" size="small" />
-              </a>
-            ))}
-          {!props.disabled &&
-            props.isExternal &&
-            (isNestedInCardLink ? (
-              <span className="mobileButton">
-                <span>Learn More</span>
-                <Icon icon="" size="small" />
-              </span>
-            ) : (
-              <a href={props.href} target="_blank" rel="noreferrer" className="mobileButton">
+              <a
+                href={props.href}
+                className="mobileButton"
+                target={props.isExternal ? "_blank" : undefined}
+                rel={props.isExternal ? "noreferrer" : undefined}
+              >
                 <span>Learn More</span>
                 <Icon icon="" size="small" />
               </a>

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -54,7 +54,7 @@ const Card = (props: CardProps) => {
     config: { mass: 9, tension: 775, friction: 65, precision: 0.00001 },
   }));
 
-  const content = (transform?: typeof springProps) => (
+  const content = (transform?: typeof springProps, isNestedInCardLink = false) => (
     <div className="root">
       <div className="container">
         <div className="cardWrapper">
@@ -69,6 +69,11 @@ const Card = (props: CardProps) => {
                   <animated.div
                     className="imageLayer"
                     style={{
+                      position: "absolute",
+                      width: "100%",
+                      height: "100%",
+                      top: 0,
+                      left: 0,
                       transform: transform
                         ? transform.xyzs.to((...args: number[]) => {
                             const [x, y, z] = args;
@@ -85,6 +90,10 @@ const Card = (props: CardProps) => {
                         aria-hidden="true"
                         fill
                         sizes="(max-width: 425px) 100vw, (max-width: 1024px) 50vw, 512px"
+                        style={{
+                          objectFit: "cover",
+                          transition: "0.35s ease",
+                        }}
                       />
                     )}
                   </animated.div>
@@ -92,18 +101,32 @@ const Card = (props: CardProps) => {
               ))}
             </div>
           </div>
-          {!props.disabled && !props.isExternal && (
-            <a href={props.href} className="mobileButton">
-              <span>Learn More</span>
-              <Icon icon="" size="small" />
-            </a>
-          )}
-          {!props.disabled && props.isExternal && (
-            <a href={props.href} target="_blank" rel="noreferrer" className="mobileButton">
-              <span>Learn More</span>
-              <Icon icon="" size="small" />
-            </a>
-          )}
+          {!props.disabled &&
+            !props.isExternal &&
+            (isNestedInCardLink ? (
+              <span className="mobileButton">
+                <span>Learn More</span>
+                <Icon icon="" size="small" />
+              </span>
+            ) : (
+              <a href={props.href} className="mobileButton">
+                <span>Learn More</span>
+                <Icon icon="" size="small" />
+              </a>
+            ))}
+          {!props.disabled &&
+            props.isExternal &&
+            (isNestedInCardLink ? (
+              <span className="mobileButton">
+                <span>Learn More</span>
+                <Icon icon="" size="small" />
+              </span>
+            ) : (
+              <a href={props.href} target="_blank" rel="noreferrer" className="mobileButton">
+                <span>Learn More</span>
+                <Icon icon="" size="small" />
+              </a>
+            ))}
           {props.disabled && (
             <span className="mobileButton disabledBar">
               <span>Contact me to learn more</span>
@@ -333,11 +356,11 @@ const Card = (props: CardProps) => {
           rel="noreferrer"
           className={props.disabled ? "disabled" : "card"}
         >
-          {content(springProps)}
+          {content(springProps, true)}
         </a>
       ) : (
         <a href={props.href} className={"card"}>
-          {content(springProps)}
+          {content(springProps, true)}
         </a>
       )}
       <style jsx>{`


### PR DESCRIPTION
## Summary

- Restore visible portfolio card images after the `next/image` migration.
- Keep the parallax image layer explicitly positioned so `fill` images have a valid parent box.
- Avoid nested card/mobile-button anchors on desktop, removing the hydration error seen during browser QA.

## Verification

- `npm run format:check`
- `npm run check`
- Production browser smoke test on `http://127.0.0.1:3172/`
  - all observed `/_next/image` requests returned 200
  - first card image rendered at `495x322`, not zero height
  - browser console reported 0 errors/warnings in production smoke

## Screenshot evidence

Captured production screenshot locally at `/tmp/portfolio-image-check-prod/home.png` and posted in the Discord thread for review.
