### PR TITLE
feat(vault): bootstrap — AGENTS.md addendum + API_CONTRACT.md (#31)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,10 @@ the operator-side contract.
 - **`schema.ts` and `fail-closed.ts` are co-owned**. Do not split them across
   parallel worktrees. They must change atomically.
 - **Public route imports MUST come from `lib/vault/index.ts`**. Never import
-  `adapter-local`, `adapter-github` directly from pages. ESLint
-  `import/no-restricted-paths` enforces this.
-- **No `eslint-disable` allowed in `lib/vault/**`**. CI greps for it and fails.
+  `adapter-local`, `adapter-github` directly from pages. The ESLint
+  `import/no-restricted-paths` enforcement lands with ticket #33.
+- **No `eslint-disable` allowed in `lib/vault/**`**. The CI grep that enforces
+  this lands with ticket #37.
 - **The leak test in CI must pass before any merge**. If it fails, the right
   response is to fix the leak — not silence the test.
 - **No module-init side effects** in `lib/vault/*`. No I/O, no env validation,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,11 @@ ticket #38) for the operator-side contract.
   Any change here MUST extend the table, not relax it.
 - **`lib/vault/schema.ts`** — never relax `default('private')`, never remove
   `passthrough()`, never change the `visibility` enum.
-- **`lib/vault/walk.ts`** — never weaken the allowlist
-  (`.obsidian/`, `.trash/`, `.git/`, `.github/`, `node_modules/`, `templates/`),
-  never change `followSymbolicLinks: false`.
+- **`lib/vault/walk.ts`** — never weaken the path **ignore-list** — directories
+  that MUST be excluded from the walk: `.obsidian/`, `.trash/`, `.git/`,
+  `.github/`, `node_modules/`, `templates/`. (The allowed-glob is `**/*.md`;
+  these directories are subtracted from it.) Never change
+  `followSymbolicLinks: false`.
 - **`schema.ts` and `fail-closed.ts` are co-owned**. Do not split them across
   parallel worktrees. They must change atomically.
 - **Public route imports MUST come from `lib/vault/index.ts`**. Never import

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,49 @@ This is Donovan Yohan's portfolio site. It uses Next.js Pages Router, React, sty
 - Use the existing Pages Router and component structure.
 - Keep generated folders (`.next`, `out`, `coverage`, `node_modules`) out of edits.
 - Future design-system work should align content and layout to the dot-grid/sketchbook direction in `DESIGN.md`.
+
+## Vault adapter — load-bearing privacy code
+
+Files in `lib/vault/**` and the leak test in `test/leak.test.ts` are the privacy
+boundary of donovanyohan.com. The vault data source is the private GitHub repo
+[`donovan-yohan/dy-journal`](https://github.com/donovan-yohan/dy-journal). See
+`API_CONTRACT.md` for the data shape and `VAULT.md` (in this repo, ships with
+ticket #38) for the operator-side contract.
+
+### Hard rules — do NOT modify without reading API_CONTRACT.md and VAULT.md
+
+- **`lib/vault/fail-closed.ts`** — `resolveVisibility()` is the privacy boundary.
+  The test table in `test/resolveVisibility.test.ts` is the authoritative spec.
+  Any change here MUST extend the table, not relax it.
+- **`lib/vault/schema.ts`** — never relax `default('private')`, never remove
+  `passthrough()`, never change the `visibility` enum.
+- **`lib/vault/walk.ts`** — never weaken the allowlist
+  (`.obsidian/`, `.trash/`, `.git/`, `.github/`, `node_modules/`, `templates/`),
+  never change `followSymbolicLinks: false`.
+- **`schema.ts` and `fail-closed.ts` are co-owned**. Do not split them across
+  parallel worktrees. They must change atomically.
+- **Public route imports MUST come from `lib/vault/index.ts`**. Never import
+  `adapter-local`, `adapter-github` directly from pages. ESLint
+  `import/no-restricted-paths` enforces this.
+- **No `eslint-disable` allowed in `lib/vault/**`**. CI greps for it and fails.
+- **The leak test in CI must pass before any merge**. If it fails, the right
+  response is to fix the leak — not silence the test.
+- **No module-init side effects** in `lib/vault/*`. No I/O, no env validation,
+  no throws at import time. Pure imports only.
+
+### Verification commands
+
+```bash
+npm test                              # vitest suite incl. leak test + resolveVisibility table
+npm run vault-lint __fixtures__/vault # checks fixture vault
+npm run vault-lint -- --report ../dy-journal  # Donovan's daily check
+npm run check                         # full lint + typecheck + tests + build
+```
+
+### Worktree etiquette (nightshift orchestration)
+
+- `lib/vault/schema.ts` and `lib/vault/fail-closed.ts` are co-owned by one ticket
+  (#32) — never modified across separate worktrees.
+- All worktrees clean themselves up on merge or abort.
+- PRs are stacked by dependency; each ticket links its base branch in the PR
+  description.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,21 @@ This is Donovan Yohan's portfolio site. It uses Next.js Pages Router, React, sty
 - Keep generated folders (`.next`, `out`, `coverage`, `node_modules`) out of edits.
 - Future design-system work should align content and layout to the dot-grid/sketchbook direction in `DESIGN.md`.
 
-## Vault adapter — load-bearing privacy code
+## Vault adapter — load-bearing privacy code (forward-looking)
+
+> **Note:** This section describes the vault adapter design that lands across
+> stacked PRs in epic #30. As of this commit, only AGENTS.md + API_CONTRACT.md
+> exist. The files referenced below (`lib/vault/**`, `test/leak.test.ts`,
+> `test/resolveVisibility.test.ts`, `npm run vault-lint`, the
+> `import/no-restricted-paths` ESLint config, the `eslint-disable` CI grep) ship
+> in tickets #32–#38. This guide is in place first so nightshift sub-agents
+> working on those tickets follow the contract from line one.
 
 Files in `lib/vault/**` and the leak test in `test/leak.test.ts` are the privacy
 boundary of donovanyohan.com. The vault data source is the private GitHub repo
 [`donovan-yohan/dy-journal`](https://github.com/donovan-yohan/dy-journal). See
-`API_CONTRACT.md` for the data shape and `VAULT.md` (in this repo, ships with
-ticket #38) for the operator-side contract.
+`API_CONTRACT.md` for the data shape and `VAULT.md` (lands with ticket #38) for
+the operator-side contract.
 
 ### Hard rules — do NOT modify without reading API_CONTRACT.md and VAULT.md
 
@@ -51,13 +59,32 @@ ticket #38) for the operator-side contract.
 - **No module-init side effects** in `lib/vault/*`. No I/O, no env validation,
   no throws at import time. Pure imports only.
 
-### Verification commands
+### Verification commands (available as tickets land)
 
+Today (post #31):
 ```bash
-npm test                              # vitest suite incl. leak test + resolveVisibility table
-npm run vault-lint __fixtures__/vault # checks fixture vault
-npm run vault-lint -- --report ../dy-journal  # Donovan's daily check
 npm run check                         # full lint + typecheck + tests + build
+npm test                              # vitest smoke tests
+```
+
+Available after #32 ships:
+```bash
+npm test                              # adds resolveVisibility table tests
+```
+
+Available after #36 ships:
+```bash
+npm run vault-lint -- __fixtures__/vault                # fixture sanity check
+npm run vault-lint -- --report <vault-path>             # daily debug
+```
+
+Replace `<vault-path>` with the absolute path to your Obsidian vault — there's
+no canonical sibling layout assumption. Donovan's local layout is
+`~/Documents/Programs/personal/dy-journal`; forkers' layouts vary.
+
+Available after #37 ships:
+```bash
+npm test                              # adds leak test as a CI gate
 ```
 
 ### Worktree etiquette (nightshift orchestration)

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -168,7 +168,7 @@ interface Props {
 
 ```tsx
 // pages/writing/[slug].tsx
-import { getPublicNotes } from '@/lib/vault';
+import { getNoteBySlug, getPublicNotes } from '@/lib/vault';
 
 export const getStaticPaths = async () => {
   const notes = await getPublicNotes();
@@ -179,8 +179,7 @@ export const getStaticPaths = async () => {
 };
 
 export const getStaticProps = async ({ params }) => {
-  const notes = await getPublicNotes();
-  const note = notes.find((n) => n.slug === params.slug);
+  const note = await getNoteBySlug(params.slug);
   if (!note) return { notFound: true };
   return { props: { note } };
 };

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -1,11 +1,22 @@
-# API_CONTRACT.md — Vault → Frontend
+# API_CONTRACT.md — Vault → Frontend (proposed)
 
 The shape and guarantees the vault adapter exposes for the bullet-journal /
 notebook UI to build against. This is the load-bearing contract.
 
-> **Source of truth:** `lib/vault/schema.ts` (Zod) is canonical; this doc is the
-> human-readable mirror. If they ever disagree, the code wins; raise a PR to fix
-> this doc.
+> **Status:** PROPOSED. The implementation lands across the stacked PRs in
+> epic #30:
+> - `lib/vault/schema.ts`, `lib/vault/index.ts` — ticket #32 / PR #42
+> - `lib/vault/adapter-local.ts`, `adapter-github.ts`, `walk.ts` — ticket #33
+> - `lib/vault/render.ts` — ticket #34
+> - `pages/writing/index.tsx`, `[slug].tsx` — ticket #35
+>
+> **Source of truth (once the code lands):** `lib/vault/schema.ts` (Zod) is
+> canonical; this doc is the human-readable mirror. If they ever disagree, the
+> code wins; raise a PR to fix this doc.
+>
+> **`import/no-restricted-paths` enforcement:** the ESLint rule + plugin lands
+> with #33. Until then this contract describes the intended boundary; CI does
+> not yet enforce it.
 
 ## Public types
 
@@ -235,7 +246,8 @@ class VaultParseError extends Error {
 ---
 
 If you're authoring notes (not building the frontend), see
-[dy-journal/AUTHORING.md](https://github.com/donovan-yohan/dy-journal/blob/master/AUTHORING.md).
+[dy-journal/AUTHORING.md](https://github.com/donovan-yohan/dy-journal/blob/HEAD/AUTHORING.md)
+(branch-agnostic link).
 If you're building the privacy adapter, see
 [VAULT.md](./VAULT.md) (lands with ticket #38) and
 [AGENTS.md](./AGENTS.md) for nightshift constraints.

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -49,6 +49,15 @@ export interface VaultAdapter {
   // Slice 1+ adds:
   // getAllNotes(): Promise<VaultNote[]>;  // authed-only
 }
+
+export interface VaultConfig {
+  source: 'local' | 'github';
+  path?: string;             // when source === 'local'
+  repoUrl?: string;          // when source === 'github' (Slice 1+)
+  token?: string;            // when source === 'github' (Slice 1+)
+  // Resolved by getVaultConfig() based on env vars; throws on missing
+  // required values when NODE_ENV === 'production'.
+}
 ```
 
 ## Public API surface
@@ -62,14 +71,26 @@ import type { VaultNote } from './schema';
  * Returns all notes from the configured vault that resolved to `public`
  * via fail-closed visibility. Sorted by `frontmatter.date` descending.
  *
- * Throws DuplicateSlugError if two notes share a slug.
- * Throws if VAULT_PATH (Slice 0) or VAULT_REPO_URL+TOKEN (Slice 1) is missing
- *   in production (NODE_ENV=production).
+ * Internally memoized: the first call walks + parses the vault; subsequent
+ * calls within the same Node process return the cached result. This keeps
+ * getStaticPaths + getStaticProps amortized to O(N) total, not O(N²).
+ *
+ * Throws DuplicateSlugError if any notes share a slug.
+ * Throws VaultConfigError if VAULT_PATH (Slice 0) or VAULT_REPO_URL+TOKEN
+ *   (Slice 1) is missing in NODE_ENV=production.
  *
  * Safe to call from getStaticProps / getStaticPaths.
  * NEVER call from public client code.
  */
 export function getPublicNotes(): Promise<VaultNote[]>;
+
+/**
+ * Convenience for /writing/[slug] getStaticProps. Equivalent to
+ * `(await getPublicNotes()).find(n => n.slug === slug) ?? null`, but
+ * shares the memoized cache with getPublicNotes() so per-slug lookups
+ * are O(1) after the first walk.
+ */
+export function getNoteBySlug(slug: string): Promise<VaultNote | null>;
 
 /**
  * Throws on missing required env vars. Called inside getStaticPaths/Props
@@ -185,9 +206,9 @@ Vercel keeps every deploy in its history; rollback = re-promote a prior deploy
 
 ```ts
 class DuplicateSlugError extends Error {
-  paths: [string, string];   // both colliding files
+  paths: string[];           // all colliding files (≥2)
   slug: string;
-  resolution: 'derived' | 'frontmatter';  // how each got the slug
+  resolutions: Array<'derived' | 'frontmatter'>; // parallel to paths
 }
 
 class VaultConfigError extends Error {

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -1,0 +1,220 @@
+# API_CONTRACT.md — Vault → Frontend
+
+The shape and guarantees the vault adapter exposes for the bullet-journal /
+notebook UI to build against. This is the load-bearing contract.
+
+> **Source of truth:** `lib/vault/schema.ts` (Zod) is canonical; this doc is the
+> human-readable mirror. If they ever disagree, the code wins; raise a PR to fix
+> this doc.
+
+## Public types
+
+```ts
+export type Visibility = 'public' | 'private';
+
+export type PreviewKind = 'text' | 'image' | 'quote' | 'embed';
+
+export interface PreviewConfig {
+  kind: PreviewKind;        // default 'text'
+  span: number;             // 1-12; default 4
+  accent?: string;          // design-token name (see DESIGN.md token list)
+  tint?: string;            // design-token name
+  headline?: string;        // overrides title for card display
+  excerpt?: string;         // default = first paragraph of body
+  image?: string;           // path/URL when kind === 'image'
+}
+
+export interface VaultFrontmatter {
+  title: string;
+  date: string;             // YYYY-MM-DD (Date object coerced to ISO; see P24)
+  slug?: string;            // optional override; otherwise derived from filename
+  visibility: Visibility;
+  preview?: Partial<PreviewConfig>;
+  // Passthrough: extra frontmatter keys (e.g. `mood`, `weather`) are preserved
+  // but ignored by the publishing pipeline.
+  [extra: string]: unknown;
+}
+
+export interface VaultNote {
+  slug: string;             // canonical URL slug (derived or frontmatter override)
+  path: string;             // vault-relative file path (e.g. "notes/2026-05-10-hello.md")
+  frontmatter: VaultFrontmatter;
+  body: string;             // SANITIZED HTML (rehype-sanitize applied; wikilinks stripped)
+  bodyMarkdown: string;     // raw markdown body, sans frontmatter (for future renderers)
+  preview: PreviewConfig;   // merged with defaults — never undefined fields
+}
+
+export interface VaultAdapter {
+  getPublicNotes(): Promise<VaultNote[]>;
+  // Slice 1+ adds:
+  // getAllNotes(): Promise<VaultNote[]>;  // authed-only
+}
+```
+
+## Public API surface
+
+`lib/vault/index.ts` exports:
+
+```ts
+import type { VaultNote } from './schema';
+
+/**
+ * Returns all notes from the configured vault that resolved to `public`
+ * via fail-closed visibility. Sorted by `frontmatter.date` descending.
+ *
+ * Throws DuplicateSlugError if two notes share a slug.
+ * Throws if VAULT_PATH (Slice 0) or VAULT_REPO_URL+TOKEN (Slice 1) is missing
+ *   in production (NODE_ENV=production).
+ *
+ * Safe to call from getStaticProps / getStaticPaths.
+ * NEVER call from public client code.
+ */
+export function getPublicNotes(): Promise<VaultNote[]>;
+
+/**
+ * Throws on missing required env vars. Called inside getStaticPaths/Props
+ * to enforce production-mode env requirements WITHOUT crashing unrelated
+ * routes at module-init time.
+ */
+export function getVaultConfig(): VaultConfig;
+```
+
+**Slice 1 will add** `getAllNotes()` — authed-only, fetches all notes
+including private. ESLint `import/no-restricted-paths` will block public
+routes from importing it. Do NOT use it from `pages/writing/**` or
+`pages/index.tsx`.
+
+## Slug rules (P11)
+
+- Default: derived from filename (kebab-case, ASCII-only, Unicode/emoji stripped).
+- Override: `frontmatter.slug` (must match `/^[a-z0-9][a-z0-9-]*$/`).
+- Duplicate slugs across the public set throw `DuplicateSlugError` at build.
+
+| Filename | Derived slug |
+|---|---|
+| `Hello World.md` | `hello-world` |
+| `2026-05-10 Daily.md` | `2026-05-10-daily` |
+| `What's New?.md` | `whats-new` |
+| `résumé.md` | `resume` |
+| `🚀 Launch.md` | `launch` |
+
+## Visibility rules (P10, fail-closed)
+
+The frontend can rely on these guarantees from `getPublicNotes()`:
+
+- Every returned note has `frontmatter.visibility === 'public'`.
+- Every returned note's frontmatter passed full schema validation.
+- Notes with malformed YAML, missing fields, typo'd visibility, etc. are NEVER
+  returned (they resolved to `private`).
+- Wikilinks in `body` (HTML) are stripped to plain text.
+- Wikilink targets to private slugs cause the build to fail (leak test).
+- HTML in markdown body is sanitized (`<script>`, `<iframe>`, `onclick=`, etc.
+  removed by `rehype-sanitize`).
+
+**Default-deny.** `visibility: public` is the only opt-in. Anything else =
+private. The frontend never receives private content via this API.
+
+## Route shapes
+
+### `/writing` (index)
+
+```tsx
+// pages/writing/index.tsx
+import { getPublicNotes } from '@/lib/vault';
+
+export const getStaticProps = async () => {
+  const notes = await getPublicNotes();
+  return { props: { notes } };
+};
+
+interface Props {
+  notes: VaultNote[];      // sorted by date desc
+}
+```
+
+### `/writing/[slug]` (detail)
+
+```tsx
+// pages/writing/[slug].tsx
+import { getPublicNotes } from '@/lib/vault';
+
+export const getStaticPaths = async () => {
+  const notes = await getPublicNotes();
+  return {
+    paths: notes.map((n) => ({ params: { slug: n.slug } })),
+    fallback: false,        // P27: no on-demand SSR for unknown slugs
+  };
+};
+
+export const getStaticProps = async ({ params }) => {
+  const notes = await getPublicNotes();
+  const note = notes.find((n) => n.slug === params.slug);
+  if (!note) return { notFound: true };
+  return { props: { note } };
+};
+
+interface Props {
+  note: VaultNote;
+}
+```
+
+## Build metadata (P29)
+
+Every build records:
+
+- `<meta name="vault-sha" content="...">` in rendered HTML — current dy-journal HEAD SHA at build.
+- `BUILD_VAULT_SHA` env var available at build time.
+- One-line build summary in stdout: `vault: N public, M private, K errors (sha: abc1234)`.
+
+Vercel keeps every deploy in its history; rollback = re-promote a prior deploy
+(no per-note version history needed in Slice 0).
+
+## What the frontend can NOT count on (yet)
+
+- **No `getAllNotes()` in Slice 0** — Slice 1 adds this for the authed dashboard.
+- **No live cross-note links** — wikilinks are stripped to plain text in
+  Slice 0. Slice 2 ships graph + backlinks.
+- **No webhook auto-rebuild** — Slice 0 deploys are manually triggered.
+- **No bullet-journal UI yet** — Slice 0 ships unstyled list routes that prove
+  the contract works. Notebook visual treatment is a separate WIP.
+- **No prefetch-safe links to private content** — `<Link>` to private slugs
+  doesn't exist; private content lives behind authed routes (`/journal/*`)
+  added in Slice 1.
+
+## Error contracts
+
+```ts
+class DuplicateSlugError extends Error {
+  paths: [string, string];   // both colliding files
+  slug: string;
+  resolution: 'derived' | 'frontmatter';  // how each got the slug
+}
+
+class VaultConfigError extends Error {
+  missing: string[];         // env var names
+}
+
+class VaultParseError extends Error {
+  path: string;              // file that failed
+  reason: 'yaml' | 'schema' | 'visibility'; // error class
+  // Per P22: this error is reported in the adapter's per-file results,
+  // NOT thrown from getPublicNotes for private-but-malformed cases.
+  // Public-but-malformed THROWS (author asked to publish, output broken).
+}
+```
+
+## Stability promise
+
+- The shapes in this doc are stable for Slice 0 and Slice 1.
+- Optional fields may be added without breaking changes.
+- Required fields cannot be added or removed without a major version bump.
+- `getAllNotes` adds in Slice 1 alongside auth.
+- Breaking changes require a CHANGELOG entry and a migration note in `VAULT.md`.
+
+---
+
+If you're authoring notes (not building the frontend), see
+[dy-journal/AUTHORING.md](https://github.com/donovan-yohan/dy-journal/blob/master/AUTHORING.md).
+If you're building the privacy adapter, see
+[VAULT.md](./VAULT.md) (lands with ticket #38) and
+[AGENTS.md](./AGENTS.md) for nightshift constraints.


### PR DESCRIPTION
## Summary

Closes #31 (portfolio-side bootstrap). Companion work in `dy-journal` repo: ✅ private repo created with sample notes + AUTHORING.md.

- **AGENTS.md** — adds vault-adapter section so nightshift sub-agents working on `lib/vault/**` know what NOT to silently relax (`resolveVisibility`, schema defaults, walk allowlist, no module-init side effects, no `eslint-disable` in vault dir, schema+fail-closed are co-owned and never split across worktrees).
- **API_CONTRACT.md** — frontend implementation contract. Public types (`VaultNote`, `PreviewConfig`, `VaultFrontmatter`), API surface (`getPublicNotes()`), route shapes for `/writing` + `/writing/[slug]`, slug rules, visibility guarantees, error contracts, stability promise.

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run typecheck` — passes (no code changes)
- [x] AGENTS.md renders cleanly
- [x] API_CONTRACT.md renders cleanly

## Stacking

Base: `master`. Subsequent PRs in this epic stack on top of merged dependencies (T2 → T3 → T4 → T5 → T6/T7/T8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Established vault adapter privacy boundaries with strict modification rules, CI gating, and co-ownership etiquette.
  * Added a formal public API contract for the notebook/journal UI: public types, adapter surface, expected endpoints/routing shapes, build metadata, and stability/compatibility promises.
  * Documented error/validation guarantees and fail-closed privacy behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/donovanyohan/pull/40)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->