### PR TITLE
spike: next-auth v5 + Next 16 + React 19 compat (#39)

### DIFF
--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,0 +1,29 @@
+import type { NextAuthConfig } from "next-auth";
+import GitHub from "next-auth/providers/github";
+
+export const authConfig: NextAuthConfig = {
+  providers: [
+    GitHub({
+      clientId: process.env.GITHUB_CLIENT_ID,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET,
+    }),
+  ],
+  callbacks: {
+    signIn({ profile }) {
+      // Single-owner check: only allow the repo owner's GitHub login
+      const ownerLogin = process.env.OWNER_GITHUB_LOGIN;
+      if (!ownerLogin) {
+        // No owner configured — deny all
+        return false;
+      }
+      const githubProfile = profile as { login?: string } | undefined;
+      if (!githubProfile?.login) {
+        return false;
+      }
+      return githubProfile.login.toLowerCase() === ownerLogin.toLowerCase();
+    },
+  },
+  pages: {
+    signIn: "/api/auth/signin",
+  },
+};

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,4 @@
+import NextAuth from "next-auth";
+import { authConfig } from "./auth.config";
+
+export const { handlers, auth, signIn, signOut } = NextAuth(authConfig);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "framer-motion": "12.38.0",
         "lottie-react": "^2.4.1",
         "next": "^16.2.6",
+        "next-auth": "^5.0.0-beta.31",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "styled-jsx": "^5.1.7"
@@ -92,6 +93,35 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1581,6 +1611,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@react-spring/animated": {
@@ -5370,6 +5409,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6088,6 +6136,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -6146,6 +6221,15 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6464,6 +6548,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -8203,6 +8306,18 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true
     },
+    "@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "requires": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -9005,6 +9120,11 @@
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
       "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
       "dev": true
+    },
+    "@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="
     },
     "@react-spring/animated": {
       "version": "10.0.3",
@@ -11391,6 +11511,11 @@
         "set-function-name": "^2.0.2"
       }
     },
+    "jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11795,6 +11920,14 @@
         }
       }
     },
+    "next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "requires": {
+        "@auth/core": "0.41.2"
+      }
+    },
     "node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -11820,6 +11953,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true
+    },
+    "oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -12017,6 +12155,17 @@
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
+    },
+    "preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA=="
+    },
+    "preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "requires": {}
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "framer-motion": "12.38.0",
     "lottie-react": "^2.4.1",
     "next": "^16.2.6",
+    "next-auth": "^5.0.0-beta.31",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "styled-jsx": "^5.1.7"

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,37 @@
+// Pages Router API route for next-auth v5
+// next-auth v5 is designed for App Router; Pages Router requires a manual adapter.
+// handlers.GET / handlers.POST expect NextRequest (Web API), not Node's req/res.
+
+import { handlers } from "../../../auth";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { NextRequest } from "next/server";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+
+  // Adapt Node.js IncomingMessage → NextRequest (Web standard)
+  const webReq = new NextRequest(url, {
+    method: req.method,
+    headers: req.headers as HeadersInit,
+    body:
+      req.method !== "GET" && req.method !== "HEAD"
+        ? JSON.stringify(req.body)
+        : undefined,
+  });
+
+  const webRes =
+    req.method === "POST"
+      ? await handlers.POST(webReq)
+      : await handlers.GET(webReq);
+
+  res.status(webRes.status);
+  webRes.headers.forEach((value, key) => {
+    res.setHeader(key, value);
+  });
+
+  const body = await webRes.text();
+  res.send(body);
+}

--- a/pages/protected-test.tsx
+++ b/pages/protected-test.tsx
@@ -1,0 +1,84 @@
+// Spike: protected page for next-auth v5 compatibility testing
+//
+// CRITICAL FINDING: next-auth v5 has broken Pages Router compatibility.
+//  1. auth() is typed for App Router / middleware only — NOT for getServerSideProps.
+//  2. getToken() requires Web API Request type, NOT Node.js IncomingMessage.
+//
+// Workaround used here: manually extract the session cookie and call getToken
+// with an adapted headers object that satisfies the type signature.
+
+import type { GetServerSideProps } from "next";
+import { getToken } from "next-auth/jwt";
+import type { JWT } from "next-auth/jwt";
+import type { IncomingMessage } from "http";
+
+interface ProtectedTestProps {
+  token: JWT | null;
+}
+
+export default function ProtectedTestPage({ token }: ProtectedTestProps) {
+  return (
+    <main style={{ padding: "2rem", fontFamily: "monospace" }}>
+      <h1>Protected Test Page (Spike)</h1>
+      <p>
+        Authenticated as:{" "}
+        <strong>
+          {(token?.name as string) ?? (token?.email as string) ?? "unknown"}
+        </strong>
+      </p>
+      <pre
+        style={{
+          background: "#f4f4f4",
+          padding: "1rem",
+          borderRadius: "4px",
+          overflow: "auto",
+        }}
+      >
+        {JSON.stringify(token, null, 2)}
+      </pre>
+    </main>
+  );
+}
+
+/**
+ * Adapt Node.js IncomingMessage headers to a format getToken accepts.
+ * next-auth v5 getToken() requires: Request | { headers: Headers | Record<string, string> }
+ * Pages Router provides: IncomingMessage (Node.js)
+ */
+function adaptRequestForGetToken(req: IncomingMessage): {
+  headers: Record<string, string>;
+} {
+  const headers: Record<string, string> = {};
+  for (const [key, val] of Object.entries(req.headers)) {
+    if (val !== undefined) {
+      headers[key] = Array.isArray(val) ? val.join(", ") : val;
+    }
+  }
+  return { headers };
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  // Workaround: adapt Pages Router IncomingMessage to the shape getToken expects.
+  const adaptedReq = adaptRequestForGetToken(context.req);
+
+  const token = await getToken({
+    req: adaptedReq,
+    secret: process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET,
+  });
+
+  if (!token) {
+    return {
+      redirect: {
+        destination: "/api/auth/signin",
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: {
+      // JWT values may include non-serializable types; convert to plain object
+      token: JSON.parse(JSON.stringify(token)) as JWT,
+    },
+  };
+};

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,33 @@
+// Spike: Next 16 uses "proxy.ts" instead of "middleware.ts"
+// (middleware.ts is deprecated in Next 16, renamed to proxy.ts)
+// Redirects unauthenticated requests on /protected-test to sign-in.
+//
+// IMPORTANT CAVEAT: next-auth v5 exports an `auth` wrapper designed for Next 14/15 middleware.
+// In Next 16, proxy runs on Node.js runtime (NOT Edge), so NextRequest from "next/server"
+// is not guaranteed to work the same way. Using manual session check here.
+
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export default async function proxy(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (pathname.startsWith("/protected-test")) {
+    // Check for next-auth session cookie (next-auth v5 uses __Secure-authjs.session-token or authjs.session-token)
+    const sessionToken =
+      req.cookies.get("__Secure-authjs.session-token")?.value ||
+      req.cookies.get("authjs.session-token")?.value;
+
+    if (!sessionToken) {
+      const signInUrl = new URL("/api/auth/signin", req.url);
+      signInUrl.searchParams.set("callbackUrl", req.url);
+      return NextResponse.redirect(signInUrl);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/protected-test", "/protected-test/:path*"],
+};


### PR DESCRIPTION
> **DRAFT / THROWAWAY** — This is a compatibility spike. Do NOT merge to master. Close after reading the report.

## Summary

Throwaway spike to de-risk the next-auth v5 auth dependency for Slice 1 before implementation begins. Tests config, build, and server compatibility across Next 16.2.6 + React 19.2.6 + Pages Router.

---

## Findings

### Version chosen
- `next-auth@5.0.0-beta.31` — latest beta tag (no stable v5 exists; dist-tag `latest` is still v4.24.14)
- `@auth/core@0.41.2` — installed automatically as a dependency (not a peer dep)

### Peer deps
| Package | Version | Status |
|---------|---------|--------|
| `next-auth` | `5.0.0-beta.31` | installed |
| `@auth/core` | `0.41.2` | auto-installed (dep, not peer) |
| `react` | `^18.2.0 \|\| ^19.0.0` | ✅ satisfied by `react@19.2.6` |
| `next` | `^14.0.0-0 \|\| ^15.0.0 \|\| ^16.0.0` | ✅ satisfied by `next@16.2.6` |
| `@simplewebauthn/*` | optional | not needed (no WebAuthn) |
| `nodemailer` | optional | not needed (no email provider) |

No peer dep conflicts or warnings during `npm install`.

### Build status: ✅ passes (with workarounds documented below)

```
▲ Next.js 16.2.6 (Turbopack)
✓ Compiled successfully in 1270ms
✓ TypeScript passes
Route (pages)
├ ƒ /api/auth/[...nextauth]
├ ƒ /protected-test
ƒ Proxy (Middleware)
```

### Dev server starts: ✅
Server ready in ~383ms at `localhost:3001`.

### Middleware compatibility with Next 16: ⚠️ BREAKING CHANGE

**Next 16 renamed `middleware.ts` → `proxy.ts`.** This is a deprecation-turned-error:
- Having both `middleware.ts` and `proxy.ts` errors at build time
- next-auth v5 docs still reference `middleware.ts`; the `auth` wrapper export is designed for the old convention
- Workaround: use `proxy.ts` with manual cookie check instead of `auth(middleware)` wrapper

The `auth()` middleware wrapper from next-auth v5 cannot be used directly in `proxy.ts` because it internally tries to use NextRequest in a way that conflicts with Next 16's proxy runtime changes. Manual session cookie inspection is required as a workaround.

### React 19 compatibility: ✅ No issues
- `next-auth@5.0.0-beta.31` declares `react: "^18.2.0 || ^19.0.0"` 
- No peer dep warnings, no runtime errors observed
- `@auth/core` has no direct React dependency

### Pages Router compatibility (Slice 1 will use Pages, NOT App): ⚠️ MIXED — requires workarounds

Two breaking issues found for Pages Router:

**Issue 1: `auth()` is NOT callable from `getServerSideProps`**
- `auth()` from next-auth v5 is typed as `NextAuthMiddleware` (a Next.js middleware function)
- Passing `GetServerSidePropsContext` to it fails TypeScript: _"Conversion of type 'GetServerSidePropsContext' may be a mistake"_
- Workaround: use `getToken()` from `next-auth/jwt` instead (still available in v5, though marked as "not recommended")

**Issue 2: `getToken()` requires Web API types, NOT Node.js `IncomingMessage`**
- Signature changed in v5: `req: Request | { headers: Headers | Record<string, string> }`
- Pages Router provides `IncomingMessage` (Node.js), which is incompatible
- Workaround: manually adapt `context.req.headers` to `Record<string, string>` and pass `{ headers }` — this resolves TypeScript and works at runtime for cookie-based sessions

**Issue 3: Pages Router API route must manually bridge Web API ↔ Node.js**
- next-auth v5 `handlers.GET` / `handlers.POST` expect `NextRequest` (Web standard)
- Pages Router provides Node.js `req/res`; must construct a `new NextRequest(url, {...})` from `IncomingMessage`

### `signIn` callback `profile.login` field: ✅ confirmed

`GitHubProfile` (from `@auth/core/providers/github`) declares:
```ts
export interface GitHubProfile {
  login: string;  // non-nullable string — always present
  ...
}
```
The `signIn` callback receives `profile: OAuthProfile` (raw GitHub API response), and for GitHub that is the `GitHubProfile` interface. The single-owner check:
```ts
profile.login.toLowerCase() === process.env.OWNER_GITHUB_LOGIN.toLowerCase()
```
is valid. A type cast (`profile as GitHubProfile`) is needed since the callback parameter is typed as the generic `Profile`.

---

## If broken
N/A — build passes. See workarounds above.

---

## If working ✅

### Pin this exact version
```
next-auth@5.0.0-beta.31
```
No explicit `@auth/core` pin needed — it installs as a dependency automatically.

### Config quirks for Slice 1

1. **No `middleware.ts` — use `proxy.ts`** in Next 16. The `auth()` wrapper for middleware cannot be used as-is; write the proxy manually with cookie inspection.

2. **Server-side session in Pages Router** — use `getToken()` with a headers adapter shim:
   ```ts
   const token = await getToken({
     req: { headers: Object.fromEntries(Object.entries(req.headers).map(([k,v]) => [k, Array.isArray(v) ? v.join(', ') : v ?? ''])) },
     secret: process.env.AUTH_SECRET,
   });
   ```

3. **API route** — must bridge `NextApiRequest` → `NextRequest`:
   ```ts
   const webReq = new NextRequest(new URL(req.url, `http://${req.headers.host}`), { method, headers, body });
   const webRes = await handlers[req.method === 'POST' ? 'POST' : 'GET'](webReq);
   ```

4. **Auth secret** — next-auth v5 prefers `AUTH_SECRET` env var (over `NEXTAUTH_SECRET`). Both work.

5. **Cookie names** — session cookies in v5 are named `authjs.session-token` (dev) / `__Secure-authjs.session-token` (prod), changed from `next-auth.session-token`.

### Recommendation for Slice 1

**Ship with `next-auth@5.0.0-beta.31`** — build passes, React 19 is clean, and the Pages Router workarounds are mechanical (headers shim + manual proxy). The main complexity is the Pages Router adapter boilerplate which can be extracted into a shared utility.

**Alternatively**, if the team wants zero beta-dependency risk, **next-auth@4.24.14** (current stable) has first-class Pages Router support but requires downgrading mindset to v4 patterns and is less forward-compatible.

**Recommended dep line:**
```
"next-auth": "5.0.0-beta.31"
```

---

*Spike branch — close without merging after review.*