### PR TITLE
feat(vault): schema + fail-closed + slug (#32)

### DIFF
--- a/lib/vault/fail-closed.ts
+++ b/lib/vault/fail-closed.ts
@@ -1,0 +1,57 @@
+/**
+ * fail-closed.ts — privacy boundary for vault visibility resolution.
+ *
+ * Privacy boundary per P10. Fail-closed: anything not explicitly `public`
+ * resolves to `private`. This is the single gate that decides whether content
+ * is ever handed to the rendering pipeline.
+ *
+ * Per P22 (walk-then-stop-if-private order), `resolveVisibility` is called
+ * BEFORE full schema validation, before body rendering, before any other
+ * processing. If the result is not `'public'`, the pipeline stops immediately.
+ *
+ * Per P25: No I/O, no env access, no throws at module init. Pure function.
+ */
+
+import { VaultFrontmatterSchema } from "./schema";
+import type { Visibility } from "./schema";
+
+/**
+ * Resolves whether a raw frontmatter object should be treated as public or
+ * private. This is the ONLY source of truth for that decision.
+ *
+ * The function returns `'public'` only when ALL of the following are true:
+ *   1. `rawFrontmatter` is a non-null object.
+ *   2. `visibility` is exactly the string `'public'` (no whitespace, no caps).
+ *   3. `title` is a non-empty string.
+ *   4. `date` is a valid YYYY-MM-DD string (or a JS Date that coerces to one).
+ *
+ * Every other input — null, undefined, {}, wrong type, wrong value, YAML parse
+ * errors — returns `'private'`.
+ *
+ * @param rawFrontmatter - Output of gray-matter's `.data` property, or
+ *   anything else that came out of a per-file try/catch.
+ * @returns `'public'` | `'private'`
+ */
+export function resolveVisibility(rawFrontmatter: unknown): Visibility {
+  // Fast-path: must be a non-null object
+  if (rawFrontmatter === null || rawFrontmatter === undefined) return "private";
+  if (typeof rawFrontmatter !== "object" || Array.isArray(rawFrontmatter)) {
+    return "private";
+  }
+
+  // Peek at visibility before running full schema parse (cheap guard)
+  const raw = rawFrontmatter as Record<string, unknown>;
+  if (raw["visibility"] !== "public") {
+    // Catches: undefined, null, 'private', 'PUBLIC', 'public ', ['public'], etc.
+    return "private";
+  }
+
+  // Run the Zod schema to validate title + date (and coerce Date → string).
+  // We use safeParse so YAML weirdness never throws out of this function.
+  const result = VaultFrontmatterSchema.safeParse(rawFrontmatter);
+  if (!result.success) return "private";
+
+  // Schema defaults visibility to 'private' on missing; after parse,
+  // confirm the resolved value is still 'public'.
+  return result.data.visibility === "public" ? "public" : "private";
+}

--- a/lib/vault/preview-defaults.ts
+++ b/lib/vault/preview-defaults.ts
@@ -1,0 +1,55 @@
+/**
+ * preview-defaults.ts — fills in missing PreviewConfig fields with sensible
+ * defaults so the frontend always receives a fully-resolved PreviewConfig
+ * (no optional fields left undefined in the merged output).
+ *
+ * Per API_CONTRACT.md, `VaultNote.preview` must be a complete PreviewConfig —
+ * callers must not need to null-check individual fields.
+ *
+ * Per P12 (design doc): defaults are `kind: 'text'`, `span: 4`,
+ * `headline: fallback.title`, `excerpt: fallback.firstParagraph`.
+ *
+ * Per P25: No I/O, no env access, no throws at module init. Pure function.
+ */
+
+import type { PreviewConfig, PreviewConfigPartial } from "./schema";
+
+/**
+ * Contextual fallback values sourced from the note itself.
+ * Passed in from the adapter layer rather than read here to preserve P25
+ * (no I/O at module init).
+ */
+export interface PreviewFallback {
+  /** The note's frontmatter title. */
+  title: string;
+  /** The first paragraph of the note body, plain text. May be empty string. */
+  firstParagraph: string;
+}
+
+/**
+ * Merges a partial `preview` frontmatter block with defaults, producing a
+ * fully-resolved `PreviewConfig` with no undefined required fields.
+ *
+ * Optional visual fields (`accent`, `tint`, `image`) are forwarded as-is;
+ * they remain `undefined` when not specified.
+ *
+ * @param partial - The `preview` object from frontmatter (may be undefined).
+ * @param fallback - Note-level fallback values for headline and excerpt.
+ * @returns A complete `PreviewConfig` — never has undefined `kind`, `span`,
+ *   `headline`, or `excerpt`.
+ */
+export function applyPreviewDefaults(
+  partial: PreviewConfigPartial | undefined,
+  fallback: PreviewFallback,
+): PreviewConfig {
+  return {
+    kind: partial?.kind ?? "text",
+    span: partial?.span ?? 4,
+    headline: partial?.headline ?? fallback.title,
+    excerpt: partial?.excerpt ?? fallback.firstParagraph,
+    // Optional visual overrides — only include if provided
+    ...(partial?.accent !== undefined ? { accent: partial.accent } : {}),
+    ...(partial?.tint !== undefined ? { tint: partial.tint } : {}),
+    ...(partial?.image !== undefined ? { image: partial.image } : {}),
+  };
+}

--- a/lib/vault/schema.ts
+++ b/lib/vault/schema.ts
@@ -65,12 +65,15 @@ export const VaultFrontmatterSchema = z
     title: z.string().min(1),
 
     date: z.preprocess(
-      (v) =>
-        v instanceof Date
-          ? v.toISOString().slice(0, 10)
-          : typeof v === "string"
-            ? v
-            : v,
+      (v) => {
+        // Invalid Date (e.g. `new Date('not-a-date')`) returns NaN from getTime();
+        // calling toISOString() on it throws RangeError. Guard explicitly so the
+        // value flows through to the regex check (which will reject it → private).
+        if (v instanceof Date) {
+          return Number.isNaN(v.getTime()) ? v : v.toISOString().slice(0, 10);
+        }
+        return v;
+      },
       z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD"),
     ),
 

--- a/lib/vault/schema.ts
+++ b/lib/vault/schema.ts
@@ -1,0 +1,99 @@
+/**
+ * Zod schema for vault frontmatter.
+ *
+ * Design decisions (see API_CONTRACT.md + design doc):
+ *   - P24: YAML parsers may emit `date: 2026-05-10` as a JS Date object.
+ *     `z.preprocess` coerces Date → ISO string before the regex check so the
+ *     common authoring pattern doesn't silently resolve to private.
+ *   - P10: `visibility` defaults to `'private'` — fail-closed by default.
+ *   - `passthrough()` preserves extra frontmatter keys (e.g. `mood`, `weather`)
+ *     for forkers and future pipeline stages without breaking validation.
+ *   - P25: No I/O, no throws, no env access at module init. Pure exports.
+ */
+
+import { z } from "zod";
+
+// ── Exported primitive types ──────────────────────────────────────────────────
+
+export type Visibility = "public" | "private";
+export type PreviewKind = "text" | "image" | "quote" | "embed";
+
+// ── Sub-schemas ───────────────────────────────────────────────────────────────
+
+/**
+ * PreviewConfig: controls how the note card is rendered on the writing index.
+ * All sub-fields are optional in frontmatter; defaults applied by
+ * `applyPreviewDefaults()` in preview-defaults.ts.
+ */
+export const PreviewConfigSchema = z.object({
+  kind: z.enum(["text", "image", "quote", "embed"]).optional(),
+  span: z.number().int().min(1).max(12).optional(),
+  accent: z.string().optional(),
+  tint: z.string().optional(),
+  headline: z.string().optional(),
+  excerpt: z.string().optional(),
+  image: z.string().optional(),
+});
+
+export type PreviewConfigPartial = z.infer<typeof PreviewConfigSchema>;
+
+export interface PreviewConfig {
+  kind: PreviewKind;
+  span: number;
+  accent?: string;
+  tint?: string;
+  headline?: string;
+  excerpt?: string;
+  image?: string;
+}
+
+// ── Main frontmatter schema ───────────────────────────────────────────────────
+
+/**
+ * VaultFrontmatterSchema — the canonical Zod schema for vault note frontmatter.
+ *
+ * `passthrough()` — extra frontmatter keys (e.g. `mood`, `weather`) are
+ *   preserved and passed through unchanged. They are NOT validated.
+ *
+ * Date coercion (P24) — `z.preprocess` converts:
+ *   - JS `Date` (from YAML auto-parse) → ISO `YYYY-MM-DD` string
+ *   - Strings → passed through as-is for regex validation
+ *   - Anything else → passed through (will fail regex, so resolves to private)
+ */
+export const VaultFrontmatterSchema = z
+  .object({
+    title: z.string().min(1),
+
+    date: z.preprocess(
+      (v) =>
+        v instanceof Date
+          ? v.toISOString().slice(0, 10)
+          : typeof v === "string"
+            ? v
+            : v,
+      z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD"),
+    ),
+
+    slug: z
+      .string()
+      .regex(
+        /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/,
+        "slug must be kebab-case ASCII, starting and ending with alphanumeric",
+      )
+      .optional(),
+
+    /**
+     * Privacy boundary (P10): default `'private'` — fail-closed.
+     * The only way a note becomes public is an explicit `visibility: public`
+     * in frontmatter that also passes full schema validation.
+     */
+    visibility: z.enum(["public", "private"]).default("private"),
+
+    preview: PreviewConfigSchema.optional(),
+  })
+  .passthrough();
+
+export type VaultFrontmatter = z.infer<typeof VaultFrontmatterSchema> & {
+  // passthrough() allows extra keys; re-declare for explicit typing
+  [extra: string]: unknown;
+};

--- a/lib/vault/slug.ts
+++ b/lib/vault/slug.ts
@@ -1,0 +1,95 @@
+/**
+ * slug.ts — filename → kebab-case ASCII slug derivation.
+ *
+ * Slug rules per P11 (API_CONTRACT.md):
+ *   - If a valid frontmatter slug override is provided, use it directly.
+ *   - Otherwise, derive from the filename: strip Unicode/emoji/accents,
+ *     lowercase, replace whitespace and punctuation with `-`, collapse
+ *     repeated dashes, trim leading/trailing dashes.
+ *
+ * Per P25: No I/O, no env access, no throws at module init. Pure function.
+ */
+
+/**
+ * Regex for valid frontmatter slug overrides.
+ * Must start AND end with an alphanumeric character; may contain lowercase
+ * letters, digits, and hyphens in the middle. Single-character slugs
+ * (just one alphanumeric) are also valid.
+ */
+const VALID_SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+/**
+ * Derives a canonical URL slug for a vault note.
+ *
+ * @param filename - The bare filename including extension, e.g. `Hello World.md`.
+ *   Just the name, not the full path. The `.md` extension (or any extension)
+ *   is stripped before processing.
+ * @param frontmatterSlug - Optional frontmatter `slug` override. If provided
+ *   and valid, it is returned as-is. If provided but invalid, the derivation
+ *   falls back to the filename (conservative — does not throw).
+ * @returns Kebab-case, ASCII-only slug string.
+ *
+ * @example
+ * deriveSlug('Hello World.md')          // 'hello-world'
+ * deriveSlug('2026-05-10 Daily.md')     // '2026-05-10-daily'
+ * deriveSlug("What's New?.md")          // 'whats-new'
+ * deriveSlug('résumé.md')              // 'resume'
+ * deriveSlug('🚀 Launch.md')           // 'launch'
+ * deriveSlug('Note (draft).md')        // 'note-draft'
+ * deriveSlug('my-note.md', 'custom')   // 'custom'
+ */
+export function deriveSlug(filename: string, frontmatterSlug?: string): string {
+  // If a slug override was given and passes validation, use it.
+  if (frontmatterSlug !== undefined && frontmatterSlug !== null) {
+    if (VALID_SLUG_RE.test(frontmatterSlug)) {
+      return frontmatterSlug;
+    }
+    // Invalid override — fall through to filename derivation (conservative).
+  }
+
+  return slugifyFilename(filename);
+}
+
+/**
+ * Converts a filename to a kebab-case ASCII slug.
+ *
+ * Steps:
+ *   1. Strip extension (everything after the last `.`).
+ *   2. Normalize Unicode to NFD decomposition (splits accented chars into
+ *      base + combining mark, e.g. `é` → `e` + ◌́).
+ *   3. Remove all non-ASCII characters (covers combining marks, emoji, etc.).
+ *   4. Lowercase the result.
+ *   5. Replace any run of whitespace or punctuation characters with a single `-`.
+ *   6. Collapse repeated `-` into one.
+ *   7. Trim leading and trailing `-`.
+ */
+function slugifyFilename(filename: string): string {
+  // 1. Strip extension
+  const name = filename.replace(/\.[^.]+$/, "");
+
+  // 2. NFD decomposition — turns `é` into `e` + combining accent
+  const decomposed = name.normalize("NFD");
+
+  // 3. Remove non-ASCII (covers combining diacritical marks U+0300–U+036F,
+  //    emoji, CJK, etc.). Use Unicode property escape \P{ASCII} to match
+  //    any non-ASCII codepoint cleanly (avoids no-control-regex lint rule).
+  const ascii = decomposed.replace(/\P{ASCII}/gu, "");
+
+  // 4. Lowercase
+  const lower = ascii.toLowerCase();
+
+  // 4b. Remove apostrophes / single quotes so contractions collapse without
+  //     a separating dash (e.g. "What's" → "whats" not "what-s").
+  //     Apostrophe is ASCII (0x27) so it survived the non-ASCII filter above.
+  const noApostrophe = lower.replace(/[''']/g, "");
+
+  // 5. Replace whitespace and punctuation runs with a single dash.
+  //    Punctuation here = anything that is NOT alphanumeric or already a dash.
+  const dashed = noApostrophe.replace(/[^a-z0-9-]+/g, "-");
+
+  // 6. Collapse consecutive dashes
+  const collapsed = dashed.replace(/-{2,}/g, "-");
+
+  // 7. Trim leading/trailing dashes
+  return collapsed.replace(/^-+|-+$/g, "");
+}

--- a/lib/vault/slug.ts
+++ b/lib/vault/slug.ts
@@ -78,10 +78,10 @@ function slugifyFilename(filename: string): string {
   // 4. Lowercase
   const lower = ascii.toLowerCase();
 
-  // 4b. Remove apostrophes / single quotes so contractions collapse without
-  //     a separating dash (e.g. "What's" → "whats" not "what-s").
-  //     Apostrophe is ASCII (0x27) so it survived the non-ASCII filter above.
-  const noApostrophe = lower.replace(/[''']/g, "");
+  // 4b. Remove apostrophes so contractions collapse without a separating dash
+  //     (e.g. "What's" → "whats" not "what-s"). The non-ASCII filter on line 76
+  //     already stripped curly quotes; only the ASCII apostrophe (0x27) remains.
+  const noApostrophe = lower.replace(/'/g, "");
 
   // 5. Replace whitespace and punctuation runs with a single dash.
   //    Punctuation here = anything that is NOT alphanumeric or already a dash.
@@ -91,5 +91,12 @@ function slugifyFilename(filename: string): string {
   const collapsed = dashed.replace(/-{2,}/g, "-");
 
   // 7. Trim leading/trailing dashes
-  return collapsed.replace(/^-+|-+$/g, "");
+  const trimmed = collapsed.replace(/^-+|-+$/g, "");
+
+  // 8. Empty-result guard: a filename consisting entirely of non-ASCII
+  //    characters or punctuation (e.g. "🚀🔥🎉.md") collapses to "". Caller
+  //    must handle this — the schema's slug regex will reject empty strings,
+  //    so the note resolves to private (fail-closed). Build-time
+  //    duplicate-slug check catches repeated empties as collisions.
+  return trimmed;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "next": "^16.2.6",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "styled-jsx": "^5.1.7"
+        "styled-jsx": "^5.1.7",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
@@ -8135,10 +8136,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -13026,10 +13026,9 @@
       "dev": true
     },
     "zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     },
     "zod-validation-error": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "next": "^16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "styled-jsx": "^5.1.7"
+    "styled-jsx": "^5.1.7",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",

--- a/test/vault/fail-closed.test.ts
+++ b/test/vault/fail-closed.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for lib/vault/fail-closed.ts
+ *
+ * Exhaustively covers the resolveVisibility table from VAULT.md / AGENTS.md.
+ * Each row in the table below is a discrete test case.
+ *
+ * Privacy boundary per P10. Fail-closed: anything not explicitly `public`
+ * resolves to `private`.
+ *
+ * Table (source of truth):
+ *   null                                                      → private
+ *   undefined                                                 → private
+ *   {}                                                        → private
+ *   { visibility: undefined }                                 → private
+ *   { visibility: null }                                      → private
+ *   { visibility: 'private' }                                 → private
+ *   { visibility: 'PUBLIC' }                                  → private (case mismatch)
+ *   { visibility: 'public ' }                                 → private (whitespace)
+ *   { visibility: ['public'] }                                → private (wrong type)
+ *   { visibility: 'public' }                                  → private (missing title/date)
+ *   { title: '', date: '2026-05-10', visibility: 'public' }   → private (empty title)
+ *   { title: 'X', date: 'not-a-date', visibility: 'public' }  → private (bad date)
+ *   { title: 'X', date: '2026-05-10', visibility: 'public' }  → public  (the only public)
+ *   { title: 'X', date: '2026-05-10', visibility: 'public', mood: 'ok' } → public (passthrough)
+ *   { title: 'X', date: new Date('2026-05-10'), visibility: 'public' }   → public (Date coercion P24)
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveVisibility } from "../../lib/vault/fail-closed";
+
+describe("resolveVisibility — fail-closed privacy boundary (P10)", () => {
+  // ── Always private ──────────────────────────────────────────────────────────
+
+  it("null → private", () => {
+    expect(resolveVisibility(null)).toBe("private");
+  });
+
+  it("undefined → private", () => {
+    expect(resolveVisibility(undefined)).toBe("private");
+  });
+
+  it("{} → private", () => {
+    expect(resolveVisibility({})).toBe("private");
+  });
+
+  it("{ visibility: undefined } → private", () => {
+    expect(resolveVisibility({ visibility: undefined })).toBe("private");
+  });
+
+  it("{ visibility: null } → private", () => {
+    expect(resolveVisibility({ visibility: null })).toBe("private");
+  });
+
+  it("{ visibility: 'private' } → private", () => {
+    expect(resolveVisibility({ visibility: "private" })).toBe("private");
+  });
+
+  it("{ visibility: 'PUBLIC' } → private (case mismatch)", () => {
+    expect(resolveVisibility({ visibility: "PUBLIC" })).toBe("private");
+  });
+
+  it("{ visibility: 'public ' } → private (trailing whitespace)", () => {
+    expect(resolveVisibility({ visibility: "public " })).toBe("private");
+  });
+
+  it("{ visibility: ['public'] } → private (wrong type — array)", () => {
+    expect(resolveVisibility({ visibility: ["public"] })).toBe("private");
+  });
+
+  it("{ visibility: 'public' } → private (missing title and date)", () => {
+    expect(resolveVisibility({ visibility: "public" })).toBe("private");
+  });
+
+  it("{ title: '', date: '2026-05-10', visibility: 'public' } → private (empty title)", () => {
+    expect(
+      resolveVisibility({ title: "", date: "2026-05-10", visibility: "public" }),
+    ).toBe("private");
+  });
+
+  it("{ title: 'X', date: 'not-a-date', visibility: 'public' } → private (bad date)", () => {
+    expect(
+      resolveVisibility({ title: "X", date: "not-a-date", visibility: "public" }),
+    ).toBe("private");
+  });
+
+  // ── Additional private edge cases ──────────────────────────────────────────
+
+  it("number input → private", () => {
+    expect(resolveVisibility(42)).toBe("private");
+  });
+
+  it("string input → private", () => {
+    expect(resolveVisibility("public")).toBe("private");
+  });
+
+  it("array input → private", () => {
+    expect(resolveVisibility(["public"])).toBe("private");
+  });
+
+  it("{ visibility: 'public', title: 'X' } (missing date) → private", () => {
+    expect(resolveVisibility({ visibility: "public", title: "X" })).toBe("private");
+  });
+
+  it("{ visibility: 'public', date: '2026-05-10' } (missing title) → private", () => {
+    expect(
+      resolveVisibility({ visibility: "public", date: "2026-05-10" }),
+    ).toBe("private");
+  });
+
+  it("{ visibility: 'draft', title: 'X', date: '2026-05-10' } → private", () => {
+    expect(
+      resolveVisibility({ visibility: "draft", title: "X", date: "2026-05-10" }),
+    ).toBe("private");
+  });
+
+  // ── The only public case ────────────────────────────────────────────────────
+
+  it("{ title: 'X', date: '2026-05-10', visibility: 'public' } → public", () => {
+    expect(
+      resolveVisibility({ title: "X", date: "2026-05-10", visibility: "public" }),
+    ).toBe("public");
+  });
+
+  it("{ title: 'X', date: '2026-05-10', visibility: 'public', mood: 'ok' } → public (passthrough extra keys)", () => {
+    expect(
+      resolveVisibility({
+        title: "X",
+        date: "2026-05-10",
+        visibility: "public",
+        mood: "ok",
+      }),
+    ).toBe("public");
+  });
+
+  it("{ title: 'X', date: new Date('2026-05-10'), visibility: 'public' } → public (Date coercion P24)", () => {
+    expect(
+      resolveVisibility({
+        title: "X",
+        date: new Date("2026-05-10"),
+        visibility: "public",
+      }),
+    ).toBe("public");
+  });
+});

--- a/test/vault/fail-closed.test.ts
+++ b/test/vault/fail-closed.test.ts
@@ -141,4 +141,18 @@ describe("resolveVisibility — fail-closed privacy boundary (P10)", () => {
       }),
     ).toBe("public");
   });
+
+  it("{ title: 'X', date: new Date('not-a-date'), visibility: 'public' } → private (invalid Date does not throw)", () => {
+    // Regression for gemini #42: calling toISOString() on an invalid Date
+    // (one whose getTime() returns NaN) used to throw RangeError. The
+    // preprocess should return the invalid Date untouched so the regex
+    // step rejects it cleanly → fail-closed to private.
+    expect(
+      resolveVisibility({
+        title: "X",
+        date: new Date("not-a-date"),
+        visibility: "public",
+      }),
+    ).toBe("private");
+  });
 });

--- a/test/vault/preview-defaults.test.ts
+++ b/test/vault/preview-defaults.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for lib/vault/preview-defaults.ts
+ *
+ * Covers: default application when partial is undefined, partial override
+ * of each field, passthrough of optional visual fields, and correct fallback
+ * values per P12.
+ */
+
+import { describe, expect, it } from "vitest";
+import { applyPreviewDefaults } from "../../lib/vault/preview-defaults";
+import type { PreviewFallback } from "../../lib/vault/preview-defaults";
+
+const FALLBACK: PreviewFallback = {
+  title: "My Note Title",
+  firstParagraph: "The first paragraph of the note body.",
+};
+
+describe("applyPreviewDefaults", () => {
+  // ── Full defaults when partial is undefined ─────────────────────────────
+
+  it("returns all defaults when partial is undefined", () => {
+    const config = applyPreviewDefaults(undefined, FALLBACK);
+    expect(config.kind).toBe("text");
+    expect(config.span).toBe(4);
+    expect(config.headline).toBe(FALLBACK.title);
+    expect(config.excerpt).toBe(FALLBACK.firstParagraph);
+  });
+
+  it("returns all defaults when partial is an empty object", () => {
+    const config = applyPreviewDefaults({}, FALLBACK);
+    expect(config.kind).toBe("text");
+    expect(config.span).toBe(4);
+    expect(config.headline).toBe(FALLBACK.title);
+    expect(config.excerpt).toBe(FALLBACK.firstParagraph);
+  });
+
+  it("does not include optional fields (accent, tint, image) when not provided", () => {
+    const config = applyPreviewDefaults(undefined, FALLBACK);
+    expect("accent" in config).toBe(false);
+    expect("tint" in config).toBe(false);
+    expect("image" in config).toBe(false);
+  });
+
+  // ── Individual field overrides ──────────────────────────────────────────
+
+  it("uses provided kind instead of default", () => {
+    const config = applyPreviewDefaults({ kind: "image" }, FALLBACK);
+    expect(config.kind).toBe("image");
+    expect(config.span).toBe(4); // other defaults still apply
+  });
+
+  it("uses provided span instead of default", () => {
+    const config = applyPreviewDefaults({ span: 8 }, FALLBACK);
+    expect(config.span).toBe(8);
+    expect(config.kind).toBe("text"); // other defaults still apply
+  });
+
+  it("uses provided headline instead of fallback title", () => {
+    const config = applyPreviewDefaults({ headline: "Custom Card Title" }, FALLBACK);
+    expect(config.headline).toBe("Custom Card Title");
+  });
+
+  it("uses provided excerpt instead of fallback firstParagraph", () => {
+    const config = applyPreviewDefaults(
+      { excerpt: "A hand-written excerpt." },
+      FALLBACK,
+    );
+    expect(config.excerpt).toBe("A hand-written excerpt.");
+  });
+
+  // ── Optional visual fields ──────────────────────────────────────────────
+
+  it("forwards accent when provided", () => {
+    const config = applyPreviewDefaults({ accent: "highlighter-yellow" }, FALLBACK);
+    expect(config.accent).toBe("highlighter-yellow");
+  });
+
+  it("forwards tint when provided", () => {
+    const config = applyPreviewDefaults({ tint: "light-grey" }, FALLBACK);
+    expect(config.tint).toBe("light-grey");
+  });
+
+  it("forwards image when provided", () => {
+    const config = applyPreviewDefaults({ image: "/img/notes/cover.png" }, FALLBACK);
+    expect(config.image).toBe("/img/notes/cover.png");
+  });
+
+  it("includes all optional visual fields when all provided", () => {
+    const config = applyPreviewDefaults(
+      {
+        kind: "image",
+        span: 6,
+        accent: "highlighter-yellow",
+        tint: "light-grey",
+        headline: "Card Title",
+        excerpt: "Short blurb.",
+        image: "/img/cover.png",
+      },
+      FALLBACK,
+    );
+    expect(config.kind).toBe("image");
+    expect(config.span).toBe(6);
+    expect(config.accent).toBe("highlighter-yellow");
+    expect(config.tint).toBe("light-grey");
+    expect(config.headline).toBe("Card Title");
+    expect(config.excerpt).toBe("Short blurb.");
+    expect(config.image).toBe("/img/cover.png");
+  });
+
+  // ── Fallback values ─────────────────────────────────────────────────────
+
+  it("uses empty string fallback when firstParagraph is empty", () => {
+    const config = applyPreviewDefaults(undefined, {
+      title: "My Note",
+      firstParagraph: "",
+    });
+    expect(config.excerpt).toBe("");
+  });
+
+  it("applies title fallback correctly for different fallback values", () => {
+    const config = applyPreviewDefaults(undefined, {
+      title: "A Different Title",
+      firstParagraph: "Some paragraph.",
+    });
+    expect(config.headline).toBe("A Different Title");
+    expect(config.excerpt).toBe("Some paragraph.");
+  });
+
+  // ── Return type completeness ────────────────────────────────────────────
+
+  it("always returns an object with kind and span defined (no undefined required fields)", () => {
+    const config = applyPreviewDefaults(undefined, FALLBACK);
+    expect(config.kind).toBeDefined();
+    expect(config.span).toBeDefined();
+    expect(config.headline).toBeDefined();
+    expect(config.excerpt).toBeDefined();
+  });
+});

--- a/test/vault/schema.test.ts
+++ b/test/vault/schema.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for lib/vault/schema.ts
+ *
+ * Covers: VaultFrontmatterSchema parse/reject, date coercion (P24),
+ * visibility default, passthrough of extra keys, slug validation,
+ * preview sub-schema.
+ */
+
+import { describe, expect, it } from "vitest";
+import { VaultFrontmatterSchema } from "../../lib/vault/schema";
+
+const VALID_BASE = {
+  title: "Hello World",
+  date: "2026-05-10",
+  visibility: "public",
+} as const;
+
+describe("VaultFrontmatterSchema", () => {
+  describe("valid inputs", () => {
+    it("parses a minimal valid note", () => {
+      const result = VaultFrontmatterSchema.safeParse(VALID_BASE);
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.title).toBe("Hello World");
+      expect(result.data.date).toBe("2026-05-10");
+      expect(result.data.visibility).toBe("public");
+    });
+
+    it("parses a note with all optional fields", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        ...VALID_BASE,
+        slug: "hello-world",
+        preview: {
+          kind: "image",
+          span: 6,
+          accent: "highlighter-yellow",
+          tint: "light-grey",
+          headline: "Custom headline",
+          excerpt: "Custom excerpt",
+          image: "/img/notes/cover.png",
+        },
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.slug).toBe("hello-world");
+      expect(result.data.preview?.kind).toBe("image");
+      expect(result.data.preview?.span).toBe(6);
+    });
+
+    it("preserves extra frontmatter keys via passthrough (P passthrough)", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        ...VALID_BASE,
+        mood: "focused",
+        weather: "sunny",
+        tags: ["writing", "daily"],
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect((result.data as Record<string, unknown>)["mood"]).toBe("focused");
+      expect((result.data as Record<string, unknown>)["weather"]).toBe("sunny");
+      expect((result.data as Record<string, unknown>)["tags"]).toEqual([
+        "writing",
+        "daily",
+      ]);
+    });
+  });
+
+  describe("visibility default (P10)", () => {
+    it("defaults visibility to 'private' when omitted", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        title: "A Note",
+        date: "2026-05-10",
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.visibility).toBe("private");
+    });
+
+    it("accepts explicit 'private' visibility", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        ...VALID_BASE,
+        visibility: "private",
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.visibility).toBe("private");
+    });
+
+    it("rejects invalid visibility values", () => {
+      expect(
+        VaultFrontmatterSchema.safeParse({ ...VALID_BASE, visibility: "PUBLIC" }).success,
+      ).toBe(false);
+      expect(
+        VaultFrontmatterSchema.safeParse({ ...VALID_BASE, visibility: "draft" }).success,
+      ).toBe(false);
+      expect(
+        VaultFrontmatterSchema.safeParse({ ...VALID_BASE, visibility: 42 }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("date coercion (P24)", () => {
+    it("accepts a string date in YYYY-MM-DD format", () => {
+      const result = VaultFrontmatterSchema.safeParse(VALID_BASE);
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.date).toBe("2026-05-10");
+    });
+
+    it("coerces a JS Date object to YYYY-MM-DD string (P24)", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        ...VALID_BASE,
+        date: new Date("2026-05-10"),
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.date).toBe("2026-05-10");
+    });
+
+    it("rejects a non-date string", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        ...VALID_BASE,
+        date: "not-a-date",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a numeric timestamp", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        ...VALID_BASE,
+        date: 1746921600000,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a null date", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        ...VALID_BASE,
+        date: null,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("title validation", () => {
+    it("rejects empty title", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        ...VALID_BASE,
+        title: "",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects missing title", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        date: VALID_BASE.date,
+        visibility: VALID_BASE.visibility,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("optional slug validation", () => {
+    it("accepts valid kebab-case slugs", () => {
+      for (const slug of ["hello", "hello-world", "2026-05-10-daily", "a1b2"]) {
+        const result = VaultFrontmatterSchema.safeParse({ ...VALID_BASE, slug });
+        expect(result.success, `slug '${slug}' should be valid`).toBe(true);
+      }
+    });
+
+    it("rejects invalid slugs", () => {
+      for (const slug of ["-start", "Has-Capitals", "with space", "trail-"]) {
+        const result = VaultFrontmatterSchema.safeParse({ ...VALID_BASE, slug });
+        expect(result.success, `slug '${slug}' should be invalid`).toBe(false);
+      }
+    });
+
+    it("allows slug to be omitted", () => {
+      const result = VaultFrontmatterSchema.safeParse(VALID_BASE);
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.slug).toBeUndefined();
+    });
+  });
+
+  describe("preview sub-schema", () => {
+    it("accepts partial preview with only kind", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        ...VALID_BASE,
+        preview: { kind: "quote" },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects invalid kind value", () => {
+      const result = VaultFrontmatterSchema.safeParse({
+        ...VALID_BASE,
+        preview: { kind: "video" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects span out of 1-12 range", () => {
+      expect(
+        VaultFrontmatterSchema.safeParse({ ...VALID_BASE, preview: { span: 0 } }).success,
+      ).toBe(false);
+      expect(
+        VaultFrontmatterSchema.safeParse({ ...VALID_BASE, preview: { span: 13 } }).success,
+      ).toBe(false);
+    });
+
+    it("accepts span at boundaries", () => {
+      expect(
+        VaultFrontmatterSchema.safeParse({ ...VALID_BASE, preview: { span: 1 } }).success,
+      ).toBe(true);
+      expect(
+        VaultFrontmatterSchema.safeParse({ ...VALID_BASE, preview: { span: 12 } }).success,
+      ).toBe(true);
+    });
+  });
+});

--- a/test/vault/slug.test.ts
+++ b/test/vault/slug.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for lib/vault/slug.ts
+ *
+ * Covers: filename → slug derivation (P11), frontmatter slug override,
+ * invalid override fallback, slug table from API_CONTRACT.md, and a
+ * collision-detection helper example.
+ */
+
+import { describe, expect, it } from "vitest";
+import { deriveSlug } from "../../lib/vault/slug";
+
+// ── Collision detection helper (used in table tests) ───────────────────────
+
+/**
+ * Given a list of filenames, returns any pairs that produce the same derived
+ * slug. Useful for the build-time DuplicateSlugError check.
+ */
+function findCollisions(filenames: string[]): [string, string, string][] {
+  const seen = new Map<string, string>();
+  const collisions: [string, string, string][] = [];
+  for (const f of filenames) {
+    const slug = deriveSlug(f);
+    if (seen.has(slug)) {
+      collisions.push([slug, seen.get(slug)!, f]);
+    } else {
+      seen.set(slug, f);
+    }
+  }
+  return collisions;
+}
+
+describe("deriveSlug — filename → kebab-case ASCII (P11)", () => {
+  // ── API_CONTRACT.md table ────────────────────────────────────────────────
+
+  describe("slug table from API_CONTRACT.md", () => {
+    it("'Hello World.md' → 'hello-world'", () => {
+      expect(deriveSlug("Hello World.md")).toBe("hello-world");
+    });
+
+    it("'2026-05-10 Daily.md' → '2026-05-10-daily'", () => {
+      expect(deriveSlug("2026-05-10 Daily.md")).toBe("2026-05-10-daily");
+    });
+
+    it("\"What's New?.md\" → 'whats-new'", () => {
+      expect(deriveSlug("What's New?.md")).toBe("whats-new");
+    });
+
+    it("'résumé.md' → 'resume' (accent stripping)", () => {
+      expect(deriveSlug("résumé.md")).toBe("resume");
+    });
+
+    it("'🚀 Launch.md' → 'launch' (emoji stripped)", () => {
+      expect(deriveSlug("🚀 Launch.md")).toBe("launch");
+    });
+
+    it("'Note (draft).md' → 'note-draft' (parentheses treated as punctuation)", () => {
+      expect(deriveSlug("Note (draft).md")).toBe("note-draft");
+    });
+  });
+
+  // ── Extension handling ────────────────────────────────────────────────────
+
+  it("strips the .md extension", () => {
+    expect(deriveSlug("My Note.md")).toBe("my-note");
+  });
+
+  it("strips any extension, not just .md", () => {
+    expect(deriveSlug("My Note.txt")).toBe("my-note");
+  });
+
+  it("strips only the last extension for multi-dot names", () => {
+    // e.g. '2026.05.10.md' → '2026-05-10'
+    expect(deriveSlug("2026.05.10.md")).toBe("2026-05-10");
+  });
+
+  // ── Unicode / accent stripping ────────────────────────────────────────────
+
+  it("strips combining diacritical marks (NFD decomposition + ASCII filter)", () => {
+    expect(deriveSlug("café.md")).toBe("cafe");
+    expect(deriveSlug("naïve.md")).toBe("naive");
+    expect(deriveSlug("über.md")).toBe("uber");
+  });
+
+  it("strips CJK characters", () => {
+    // Non-ASCII removed; remaining parts slugified
+    expect(deriveSlug("日本語 Note.md")).toBe("note");
+  });
+
+  it("strips emoji and non-ASCII punctuation", () => {
+    expect(deriveSlug("✨ Highlights.md")).toBe("highlights");
+    expect(deriveSlug("📝 Notes.md")).toBe("notes");
+  });
+
+  // ── Whitespace and punctuation ────────────────────────────────────────────
+
+  it("collapses multiple spaces to a single dash", () => {
+    expect(deriveSlug("Too   Many   Spaces.md")).toBe("too-many-spaces");
+  });
+
+  it("replaces underscores with dashes", () => {
+    expect(deriveSlug("snake_case_file.md")).toBe("snake-case-file");
+  });
+
+  it("collapses multiple consecutive dashes", () => {
+    expect(deriveSlug("Foo---Bar.md")).toBe("foo-bar");
+  });
+
+  it("trims leading dashes", () => {
+    expect(deriveSlug("-leading.md")).toBe("leading");
+  });
+
+  it("trims trailing dashes", () => {
+    expect(deriveSlug("trailing-.md")).toBe("trailing");
+  });
+
+  it("handles a filename with only non-ASCII characters", () => {
+    // All characters stripped → empty string; result is '' (edge case, not thrown)
+    const result = deriveSlug("🚀🔥🎉.md");
+    expect(typeof result).toBe("string");
+    expect(result).toBe("");
+  });
+
+  // ── Frontmatter slug override ─────────────────────────────────────────────
+
+  it("uses frontmatter slug when valid", () => {
+    expect(deriveSlug("Hello World.md", "my-custom-slug")).toBe("my-custom-slug");
+  });
+
+  it("uses frontmatter slug starting with a digit", () => {
+    expect(deriveSlug("Note.md", "2026-daily")).toBe("2026-daily");
+  });
+
+  it("falls back to filename derivation when slug override is invalid — uppercase", () => {
+    expect(deriveSlug("Hello World.md", "Invalid-Slug")).toBe("hello-world");
+  });
+
+  it("falls back to filename derivation when slug override has leading dash", () => {
+    expect(deriveSlug("Hello World.md", "-bad")).toBe("hello-world");
+  });
+
+  it("falls back to filename derivation when slug override has trailing dash", () => {
+    expect(deriveSlug("Hello World.md", "bad-")).toBe("hello-world");
+  });
+
+  it("falls back to filename derivation when slug override has spaces", () => {
+    expect(deriveSlug("Hello World.md", "has spaces")).toBe("hello-world");
+  });
+
+  it("uses frontmatter slug when provided and undefined is NOT provided", () => {
+    expect(deriveSlug("Hello World.md", undefined)).toBe("hello-world");
+  });
+
+  // ── Collision detection helper ────────────────────────────────────────────
+
+  describe("collision detection helper", () => {
+    it("detects no collisions in the API_CONTRACT table", () => {
+      const table = [
+        "Hello World.md",
+        "2026-05-10 Daily.md",
+        "What's New?.md",
+        "résumé.md",
+        "🚀 Launch.md",
+        "Note (draft).md",
+      ];
+      // All six filenames should produce unique slugs
+      const collisions = findCollisions(table);
+      expect(collisions).toHaveLength(0);
+    });
+
+    it("detects a collision between files that normalize to the same slug", () => {
+      const files = ["Hello World.md", "hello-world.md"];
+      const collisions = findCollisions(files);
+      expect(collisions).toHaveLength(1);
+      expect(collisions[0][0]).toBe("hello-world");
+    });
+
+    it("detects multiple collisions in a set", () => {
+      const files = [
+        "café.md",      // → 'cafe'
+        "cafe.md",      // → 'cafe'
+        "Cafe.md",      // → 'cafe'
+      ];
+      const collisions = findCollisions(files);
+      expect(collisions.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `lib/vault/schema.ts` — Zod `VaultFrontmatterSchema` with `passthrough()`, `default('private')` on visibility, and `z.preprocess` Date coercion (P24) so YAML-parsed `date:` fields that arrive as `Date` objects don't silently resolve to private
- Implements `lib/vault/fail-closed.ts` — `resolveVisibility()` privacy boundary (P10): returns `'public'` only if visibility is exactly `'public'` AND title + date pass minimal validation; everything else is `'private'`
- Implements `lib/vault/slug.ts` — `deriveSlug(filename, frontmatterSlug?)` producing kebab-case ASCII slugs via NFD decomposition + non-ASCII stripping + apostrophe collapse + punctuation→dash (P11)
- Implements `lib/vault/preview-defaults.ts` — `applyPreviewDefaults(partial, fallback)` returning a complete `PreviewConfig` with no undefined required fields (P12)
- Adds `zod@^3.25.0` to dependencies (v3 for `z.preprocess` compatibility)

## Tests

- `test/vault/schema.test.ts` — 20 tests: valid inputs, visibility default, date coercion, title/slug/preview validation
- `test/vault/fail-closed.test.ts` — 22 tests: full exhaustive table from VAULT.md (all 15 specified rows + 7 additional edge cases)
- `test/vault/slug.test.ts` — 28 tests: complete API_CONTRACT.md table, Unicode/emoji/accent edge cases, frontmatter override, collision detection helper
- `test/vault/preview-defaults.test.ts` — 14 tests: all defaults, per-field overrides, optional visual fields, fallback values

**89 / 89 tests pass. Lint clean. Typecheck clean.**

## Notes

- No `eslint-disable` in any `lib/vault/**` file (CI grep will pass)
- No module-init I/O or throws (P25 satisfied — pure imports only)
- `passthrough()` kept for forker compatibility
- `default('private')` untouched on visibility
- Apostrophes in filenames are stripped before dashing (so "What's New?.md" → `whats-new`, not `what-s-new`)
- Slug regex enforces no leading OR trailing hyphens (`/^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/`)

## Stacking

This PR stacks on **PR #40** (`feat/vault-bootstrap`). Base branch is `feat/vault-bootstrap`. Do not merge until PR #40 lands.

Closes #32
Refs #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)