### PR TITLE
feat(vault): vault-lint CLI with --report mode (#36)

### DIFF
--- a/__fixtures__/vault/notes/hello-world.md
+++ b/__fixtures__/vault/notes/hello-world.md
@@ -1,0 +1,7 @@
+---
+title: Hello World
+date: 2026-05-10
+visibility: public
+---
+
+This is a public note in the fixture vault.

--- a/__fixtures__/vault/notes/no-visibility.md
+++ b/__fixtures__/vault/notes/no-visibility.md
@@ -1,0 +1,6 @@
+---
+title: No Visibility Set
+date: 2026-05-08
+---
+
+This note has no visibility field - defaults to private (fail-closed).

--- a/__fixtures__/vault/notes/private-note.md
+++ b/__fixtures__/vault/notes/private-note.md
@@ -1,0 +1,7 @@
+---
+title: Private Note
+date: 2026-05-09
+visibility: private
+---
+
+This note is private.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.6",
+        "js-yaml": "^4.1.1",
         "jsdom": "^29.1.1",
         "prettier": "^3.8.3",
         "tsx": "^4.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "25.6.2",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
@@ -31,6 +32,7 @@
         "eslint-config-next": "^16.2.6",
         "jsdom": "^29.1.1",
         "prettier": "^3.8.3",
+        "tsx": "^4.21.0",
         "typescript": "6.0.3",
         "typescript-eslint": "^8.59.2",
         "vitest": "^4.1.5"
@@ -548,6 +550,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2142,6 +2586,13 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3831,6 +4282,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -7454,6 +7947,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8473,6 +8986,188 @@
         "tslib": "^2.4.0"
       }
     },
+    "@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "dev": true,
+      "optional": true
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -9333,6 +10028,12 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true
     },
     "@types/json-schema": {
@@ -10385,6 +11086,40 @@
         "is-callable": "^1.2.7",
         "is-date-object": "^1.0.5",
         "is-symbol": "^1.0.4"
+      }
+    },
+    "esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "requires": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "escalade": {
@@ -12662,6 +13397,17 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "requires": {
+        "esbuild": "~0.27.0",
+        "fsevents": "~2.3.3",
+        "get-tsconfig": "^4.7.5"
+      }
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.6",
+    "js-yaml": "^4.1.1",
     "jsdom": "^29.1.1",
     "prettier": "^3.8.3",
     "tsx": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
+    "vault-lint": "tsx scripts/vault-lint.ts",
     "check": "npm run lint && npm run typecheck && npm run test:run && npm run build"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "25.6.2",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
@@ -38,6 +40,7 @@
     "eslint-config-next": "^16.2.6",
     "jsdom": "^29.1.1",
     "prettier": "^3.8.3",
+    "tsx": "^4.21.0",
     "typescript": "6.0.3",
     "typescript-eslint": "^8.59.2",
     "vitest": "^4.1.5"

--- a/scripts/vault-lint.ts
+++ b/scripts/vault-lint.ts
@@ -1,0 +1,414 @@
+/**
+ * vault-lint.ts — CLI that walks a vault directory and checks:
+ *   1. Schema validity (via VaultFrontmatterSchema / resolveVisibility)
+ *   2. Slug uniqueness across the entire walked set (P11)
+ *
+ * Usage:
+ *   npm run vault-lint -- <vault-path>
+ *   npm run vault-lint -- --report <vault-path>
+ *   npm run vault-lint -- --json <vault-path>
+ *
+ * Exit codes:
+ *   0 — no errors
+ *   1 — one or more schema/slug/yaml errors
+ *
+ * Design decisions (see API_CONTRACT.md, DESIGN.md P23, P11):
+ *   - Fail-closed: any file that can't be parsed is flagged as an error.
+ *   - No I/O at module init; all side-effects inside main().
+ *   - js-yaml is already in node_modules (transitive dep of @eslint/eslintrc).
+ *   - No eslint-disable directives anywhere.
+ */
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, relative, basename } from "path";
+import { load as yamlLoad } from "js-yaml";
+import { resolveVisibility } from "../lib/vault/fail-closed.js";
+import { deriveSlug } from "../lib/vault/slug.js";
+import { VaultFrontmatterSchema } from "../lib/vault/schema.js";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type FileStatus = "public" | "private" | "error";
+
+interface FileResult {
+  path: string;
+  status: FileStatus;
+  reason?: string;
+}
+
+interface LintError {
+  path: string;
+  kind: "duplicate-slug" | "schema" | "yaml";
+  message: string;
+}
+
+interface LintSummary {
+  walked: number;
+  public: number;
+  private: number;
+  errors: number;
+}
+
+interface LintOutput {
+  summary: LintSummary;
+  files: FileResult[];
+  errors: LintError[];
+}
+
+// ── YAML frontmatter parser ───────────────────────────────────────────────────
+
+interface ParseResult {
+  frontmatter: unknown;
+  parseError: string | null;
+}
+
+/**
+ * Parses YAML frontmatter from a markdown file's raw content.
+ * Returns the parsed data object, or null + an error message on failure.
+ *
+ * Frontmatter must be fenced by `---` lines at the top of the file.
+ * Files without a frontmatter block return an empty object (not an error —
+ * the schema validator will mark them private via fail-closed defaults).
+ */
+function parseFrontmatter(content: string): ParseResult {
+  const firstLine = content.startsWith("---");
+  if (!firstLine) {
+    return { frontmatter: {}, parseError: null };
+  }
+
+  // Find the closing ---
+  const rest = content.slice(3);
+  const closeIdx = rest.search(/\n---(\n|$)/);
+  if (closeIdx === -1) {
+    return { frontmatter: {}, parseError: null };
+  }
+
+  const yamlBlock = rest.slice(0, closeIdx);
+
+  try {
+    const parsed = yamlLoad(yamlBlock);
+    return { frontmatter: parsed ?? {}, parseError: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { frontmatter: null, parseError: message };
+  }
+}
+
+// ── Vault walker ──────────────────────────────────────────────────────────────
+
+/**
+ * Recursively walks a directory and returns all .md file absolute paths.
+ * Skips hidden directories (names starting with `.`) like .obsidian, .trash.
+ */
+function walkVault(dir: string): string[] {
+  const results: string[] = [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir, { encoding: "utf-8" });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (entry.startsWith(".")) continue; // skip hidden (obsidian, trash, git)
+
+    const fullPath = join(dir, entry);
+    let stat: ReturnType<typeof statSync>;
+    try {
+      stat = statSync(fullPath);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      results.push(...walkVault(fullPath));
+    } else if (entry.endsWith(".md")) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+// ── Core lint logic ───────────────────────────────────────────────────────────
+
+/**
+ * Lints a single .md file. Returns a FileResult and any errors found.
+ * Does NOT throw — all errors are captured and returned.
+ */
+function lintFile(
+  filePath: string,
+  vaultRoot: string,
+): { result: FileResult; errors: LintError[] } {
+  const relPath = relative(vaultRoot, filePath);
+  const errors: LintError[] = [];
+
+  // Read file
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      result: { path: relPath, status: "error", reason: `read error: ${message}` },
+      errors: [{ path: relPath, kind: "yaml", message: `read error: ${message}` }],
+    };
+  }
+
+  // Parse frontmatter
+  const { frontmatter, parseError } = parseFrontmatter(content);
+  if (parseError !== null) {
+    return {
+      result: {
+        path: relPath,
+        status: "error",
+        reason: `yaml parse error: ${parseError}`,
+      },
+      errors: [
+        {
+          path: relPath,
+          kind: "yaml",
+          message: `YAML parse error: ${parseError}`,
+        },
+      ],
+    };
+  }
+
+  // Resolve visibility (fail-closed)
+  const visibility = resolveVisibility(frontmatter);
+
+  if (visibility === "private") {
+    // Determine why — attempt schema parse to surface the reason
+    const schemaResult = VaultFrontmatterSchema.safeParse(frontmatter);
+    let reason = "visibility not public";
+
+    if (schemaResult.success) {
+      // Schema passed but visibility is not 'public'
+      const fm = frontmatter as Record<string, unknown>;
+      if (fm["visibility"] === undefined) {
+        reason = "no visibility field (defaults to private)";
+      } else {
+        reason = `visibility: ${String(fm["visibility"])} (not public)`;
+      }
+    } else {
+      // Schema failed — report the first issue
+      const issues = schemaResult.error.issues;
+      if (issues.length > 0) {
+        const issue = issues[0];
+        reason = `schema error: ${issue.path.join(".") || "root"}: ${issue.message}`;
+      }
+    }
+
+    return { result: { path: relPath, status: "private", reason }, errors };
+  }
+
+  // Public — run full schema validation and report schema errors
+  const schemaResult = VaultFrontmatterSchema.safeParse(frontmatter);
+  if (!schemaResult.success) {
+    // This shouldn't happen if resolveVisibility passed, but defend anyway
+    const issues = schemaResult.error.issues
+      .map((i) => `${i.path.join(".") || "root"}: ${i.message}`)
+      .join("; ");
+    errors.push({
+      path: relPath,
+      kind: "schema",
+      message: `schema validation failed: ${issues}`,
+    });
+    return {
+      result: {
+        path: relPath,
+        status: "error",
+        reason: `schema error: ${issues}`,
+      },
+      errors,
+    };
+  }
+
+  return { result: { path: relPath, status: "public" }, errors };
+}
+
+/**
+ * Runs the full lint pass over a vault directory.
+ * Returns structured results including per-file status and all errors.
+ */
+function lintVault(vaultPath: string): LintOutput {
+  const mdFiles = walkVault(vaultPath);
+  const fileResults: FileResult[] = [];
+  const allErrors: LintError[] = [];
+
+  // Per-file slug map for duplicate detection (slug → relPath)
+  const slugMap = new Map<string, string>();
+
+  for (const filePath of mdFiles) {
+    const relPath = relative(vaultPath, filePath);
+    const { result, errors } = lintFile(filePath, vaultPath);
+    fileResults.push(result);
+    allErrors.push(...errors);
+
+    // Slug uniqueness check — run for all files (not just public)
+    // so authors catch collisions before publishing
+    if (result.status !== "error") {
+      let frontmatterSlug: string | undefined;
+      try {
+        const content = readFileSync(filePath, "utf-8");
+        const { frontmatter } = parseFrontmatter(content);
+        if (
+          frontmatter !== null &&
+          typeof frontmatter === "object" &&
+          !Array.isArray(frontmatter)
+        ) {
+          const fm = frontmatter as Record<string, unknown>;
+          if (typeof fm["slug"] === "string") {
+            frontmatterSlug = fm["slug"];
+          }
+        }
+      } catch {
+        // already handled by lintFile
+      }
+
+      const slug = deriveSlug(basename(filePath), frontmatterSlug);
+      const existing = slugMap.get(slug);
+      if (existing !== undefined) {
+        const dupError: LintError = {
+          path: relPath,
+          kind: "duplicate-slug",
+          message: `duplicate slug "${slug}" — also used by ${existing}`,
+        };
+        allErrors.push(dupError);
+
+        // Also flag the first file with the dup error if not already
+        const firstDupError: LintError = {
+          path: existing,
+          kind: "duplicate-slug",
+          message: `duplicate slug "${slug}" — also used by ${relPath}`,
+        };
+        allErrors.push(firstDupError);
+
+        // Mark the current file as error
+        const idx = fileResults.findIndex((r) => r.path === relPath);
+        if (idx !== -1) {
+          fileResults[idx] = {
+            path: relPath,
+            status: "error",
+            reason: dupError.message,
+          };
+        }
+      } else {
+        slugMap.set(slug, relPath);
+      }
+    }
+  }
+
+  const summary: LintSummary = {
+    walked: fileResults.length,
+    public: fileResults.filter((r) => r.status === "public").length,
+    private: fileResults.filter((r) => r.status === "private").length,
+    errors: allErrors.length,
+  };
+
+  return { summary, files: fileResults, errors: allErrors };
+}
+
+// ── CLI entrypoint ────────────────────────────────────────────────────────────
+
+/**
+ * Parses CLI args. Returns { vaultPath, report, json }.
+ * Exits with usage message on bad args.
+ */
+function parseArgs(argv: string[]): {
+  vaultPath: string;
+  report: boolean;
+  json: boolean;
+} {
+  const args = argv.slice(2); // drop node + script path
+  let report = false;
+  let json = false;
+  const positional: string[] = [];
+
+  for (const arg of args) {
+    if (arg === "--report") {
+      report = true;
+    } else if (arg === "--json") {
+      json = true;
+    } else if (arg.startsWith("-")) {
+      process.stderr.write(`Unknown flag: ${arg}\n`);
+      process.stderr.write(
+        "Usage: vault-lint [--report] [--json] <vault-path>\n",
+      );
+      process.exit(1);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (positional.length !== 1) {
+    process.stderr.write("Usage: vault-lint [--report] [--json] <vault-path>\n");
+    process.exit(1);
+  }
+
+  return { vaultPath: positional[0], report, json };
+}
+
+/**
+ * Main CLI entrypoint. Pure function over process.argv / process.exit.
+ * Exported so tests can call it with synthetic argv and capture exit code.
+ */
+export function main(argv: string[]): number {
+  const { vaultPath, report, json } = parseArgs(argv);
+
+  const output = lintVault(vaultPath);
+  const { summary, files, errors } = output;
+
+  if (json) {
+    // Machine-readable: emit JSON to stdout, nothing to stderr
+    process.stdout.write(JSON.stringify(output, null, 2) + "\n");
+    return errors.length > 0 ? 1 : 0;
+  }
+
+  // Human-readable output to stderr
+
+  if (report) {
+    // --report: list every file with status and reason
+    process.stderr.write(
+      `vault-lint report — walked ${summary.walked} files\n`,
+    );
+    process.stderr.write(
+      `  public: ${summary.public}  private: ${summary.private}  errors: ${summary.errors}\n\n`,
+    );
+
+    for (const file of files) {
+      const tag = file.status === "public" ? "[public] " : file.status === "private" ? "[private]" : "[error]  ";
+      const reason = file.reason !== undefined ? `  — ${file.reason}` : "";
+      process.stderr.write(`  ${tag}  ${file.path}${reason}\n`);
+    }
+
+    if (errors.length > 0) {
+      process.stderr.write("\nErrors:\n");
+      for (const err of errors) {
+        process.stderr.write(`  [${err.kind}] ${err.path}: ${err.message}\n`);
+      }
+    }
+  } else {
+    // Default: only emit errors
+    if (errors.length > 0) {
+      for (const err of errors) {
+        process.stderr.write(`[${err.kind}] ${err.path}: ${err.message}\n`);
+      }
+    }
+  }
+
+  const ok = errors.length === 0;
+  if (!report && !json && ok) {
+    process.stderr.write(
+      `vault-lint: ${summary.walked} files walked, ${summary.public} public, ${summary.private} private — OK\n`,
+    );
+  }
+
+  return ok ? 0 : 1;
+}
+
+// Run when invoked directly (not imported by tests)
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv));
+}

--- a/scripts/vault-lint.ts
+++ b/scripts/vault-lint.ts
@@ -19,7 +19,8 @@
  *   - No eslint-disable directives anywhere.
  */
 
-import { readFileSync, readdirSync, statSync } from "fs";
+import { readFileSync, readdirSync, lstatSync } from "fs";
+import type { Dirent } from "fs";
 import { join, relative, basename } from "path";
 import { load as yamlLoad } from "js-yaml";
 import { resolveVisibility } from "../lib/vault/fail-closed.js";
@@ -38,7 +39,7 @@ interface FileResult {
 
 interface LintError {
   path: string;
-  kind: "duplicate-slug" | "schema" | "yaml";
+  kind: "duplicate-slug" | "schema" | "yaml" | "io" | "args";
   message: string;
 }
 
@@ -80,7 +81,14 @@ function parseFrontmatter(content: string): ParseResult {
   const rest = content.slice(3);
   const closeIdx = rest.search(/\n---(\n|$)/);
   if (closeIdx === -1) {
-    return { frontmatter: {}, parseError: null };
+    // Opening fence without closing fence = malformed frontmatter (not "no
+    // frontmatter"). Treating it as `{}` would silently let bad authoring
+    // pass — which conflicts with fail-closed intent. Surface it as a parse
+    // error so the lint flags it. (copilot #45)
+    return {
+      frontmatter: null,
+      parseError: "opening `---` without closing `---` fence",
+    };
   }
 
   const yamlBlock = rest.slice(0, closeIdx);
@@ -97,50 +105,98 @@ function parseFrontmatter(content: string): ParseResult {
 // ── Vault walker ──────────────────────────────────────────────────────────────
 
 /**
- * Recursively walks a directory and returns all .md file absolute paths.
- * Skips hidden directories (names starting with `.`) like .obsidian, .trash.
+ * Recursively walks a directory and returns all `.md` file absolute paths.
+ * Excludes hidden directories (`.obsidian`, `.trash`, `.git`, `.github`) plus
+ * `node_modules`, `templates` per VAULT.md walk-ignore-list.
+ *
+ * Uses `withFileTypes` to avoid an extra `lstatSync` per entry (perf).
+ * Symlinks are explicitly NOT followed — matches `lib/vault/walk.ts` policy.
+ *
+ * Returns `{ files, error }`. On readdir failure (missing dir, permissions,
+ * not a directory), `error` is set so the caller can fail loudly. (copilot #45)
  */
-function walkVault(dir: string): string[] {
-  const results: string[] = [];
+const IGNORED_DIRS = new Set([
+  ".obsidian",
+  ".trash",
+  ".git",
+  ".github",
+  "node_modules",
+  "templates",
+]);
 
-  let entries: string[];
-  try {
-    entries = readdirSync(dir, { encoding: "utf-8" });
-  } catch {
-    return results;
-  }
+interface WalkResult {
+  files: string[];
+  error: string | null;
+}
 
-  for (const entry of entries) {
-    if (entry.startsWith(".")) continue; // skip hidden (obsidian, trash, git)
+function walkVault(dir: string): WalkResult {
+  const out: string[] = [];
 
-    const fullPath = join(dir, entry);
-    let stat: ReturnType<typeof statSync>;
+  function recurse(d: string): string | null {
+    // `withFileTypes: true` returns Dirent[] which exposes
+    // isDirectory()/isFile()/isSymbolicLink() without an extra lstat per entry.
+    let entries: Dirent[];
     try {
-      stat = statSync(fullPath);
-    } catch {
-      continue;
+      entries = readdirSync(d, { withFileTypes: true }) as Dirent[];
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
     }
 
-    if (stat.isDirectory()) {
-      results.push(...walkVault(fullPath));
-    } else if (entry.endsWith(".md")) {
-      results.push(fullPath);
+    for (const entry of entries) {
+      const name = entry.name;
+      if (IGNORED_DIRS.has(name)) continue;
+      // Skip every other dotfile / dotdir too (e.g. `.DS_Store`, `.idea/`,
+      // user-added hidden caches). Vaults rarely intend to publish dotfiles.
+      if (name.startsWith(".")) continue;
+
+      const fullPath = join(d, name);
+
+      // `withFileTypes` returns Dirent; `isSymbolicLink()` is direct, no extra
+      // syscall. Skip symlinks regardless of target — matches the
+      // `followSymbolicLinks: false` policy in lib/vault/walk.ts. (copilot #45)
+      if (entry.isSymbolicLink()) continue;
+
+      if (entry.isDirectory()) {
+        const subErr = recurse(fullPath);
+        if (subErr !== null) return subErr;
+      } else if (entry.isFile() && name.endsWith(".md")) {
+        out.push(fullPath);
+      }
     }
+    return null;
   }
 
-  return results;
+  // Verify the root is actually a directory before recursing. Handles
+  // missing dir, file-instead-of-dir, permission denied — all surface as
+  // a clear error rather than the silent "0 files walked" we used to
+  // return. (copilot #45)
+  let rootStat: ReturnType<typeof lstatSync>;
+  try {
+    rootStat = lstatSync(dir);
+  } catch (err) {
+    return { files: [], error: err instanceof Error ? err.message : String(err) };
+  }
+  if (!rootStat.isDirectory()) {
+    return { files: [], error: `not a directory: ${dir}` };
+  }
+
+  const recurseErr = recurse(dir);
+  return { files: out, error: recurseErr };
 }
 
 // ── Core lint logic ───────────────────────────────────────────────────────────
 
 /**
- * Lints a single .md file. Returns a FileResult and any errors found.
+ * Lints a single .md file. Returns a FileResult, the parsed frontmatter, and
+ * any errors found. Returning the frontmatter avoids a second read+parse pass
+ * during slug-uniqueness checks. (gemini + copilot #45)
+ *
  * Does NOT throw — all errors are captured and returned.
  */
 function lintFile(
   filePath: string,
   vaultRoot: string,
-): { result: FileResult; errors: LintError[] } {
+): { result: FileResult; errors: LintError[]; frontmatter: unknown } {
   const relPath = relative(vaultRoot, filePath);
   const errors: LintError[] = [];
 
@@ -152,7 +208,10 @@ function lintFile(
     const message = err instanceof Error ? err.message : String(err);
     return {
       result: { path: relPath, status: "error", reason: `read error: ${message}` },
-      errors: [{ path: relPath, kind: "yaml", message: `read error: ${message}` }],
+      // Use kind: "io" for read failures so downstream automation can
+      // distinguish them from actual YAML parse problems. (copilot #45)
+      errors: [{ path: relPath, kind: "io", message: `read error: ${message}` }],
+      frontmatter: null,
     };
   }
 
@@ -172,6 +231,7 @@ function lintFile(
           message: `YAML parse error: ${parseError}`,
         },
       ],
+      frontmatter: null,
     };
   }
 
@@ -200,7 +260,7 @@ function lintFile(
       }
     }
 
-    return { result: { path: relPath, status: "private", reason }, errors };
+    return { result: { path: relPath, status: "private", reason }, errors, frontmatter };
   }
 
   // Public — run full schema validation and report schema errors
@@ -222,10 +282,11 @@ function lintFile(
         reason: `schema error: ${issues}`,
       },
       errors,
+      frontmatter,
     };
   }
 
-  return { result: { path: relPath, status: "public" }, errors };
+  return { result: { path: relPath, status: "public" }, errors, frontmatter };
 }
 
 /**
@@ -233,65 +294,77 @@ function lintFile(
  * Returns structured results including per-file status and all errors.
  */
 function lintVault(vaultPath: string): LintOutput {
-  const mdFiles = walkVault(vaultPath);
+  const walked = walkVault(vaultPath);
   const fileResults: FileResult[] = [];
   const allErrors: LintError[] = [];
 
-  // Per-file slug map for duplicate detection (slug → relPath)
+  // Surface walk failure (non-existent / unreadable / not-a-directory) as a
+  // first-class error so vault-lint never silently reports OK on bad input.
+  // (copilot #45)
+  if (walked.error !== null) {
+    allErrors.push({
+      path: vaultPath,
+      kind: "io",
+      message: `walk failed: ${walked.error}`,
+    });
+    return {
+      summary: { walked: 0, public: 0, private: 0, errors: 1 },
+      files: [],
+      errors: allErrors,
+    };
+  }
+
+  // Per-file slug map: slug → relPath of the FIRST file that claimed it
   const slugMap = new Map<string, string>();
 
-  for (const filePath of mdFiles) {
+  for (const filePath of walked.files) {
     const relPath = relative(vaultPath, filePath);
-    const { result, errors } = lintFile(filePath, vaultPath);
+    const { result, errors, frontmatter } = lintFile(filePath, vaultPath);
     fileResults.push(result);
     allErrors.push(...errors);
 
-    // Slug uniqueness check — run for all files (not just public)
-    // so authors catch collisions before publishing
+    // Slug uniqueness — run for all files (not just public) so authors catch
+    // collisions before publishing. Use the parsed frontmatter from lintFile
+    // instead of re-reading the file. (gemini + copilot #45)
     if (result.status !== "error") {
       let frontmatterSlug: string | undefined;
-      try {
-        const content = readFileSync(filePath, "utf-8");
-        const { frontmatter } = parseFrontmatter(content);
-        if (
-          frontmatter !== null &&
-          typeof frontmatter === "object" &&
-          !Array.isArray(frontmatter)
-        ) {
-          const fm = frontmatter as Record<string, unknown>;
-          if (typeof fm["slug"] === "string") {
-            frontmatterSlug = fm["slug"];
-          }
+      if (
+        frontmatter !== null &&
+        typeof frontmatter === "object" &&
+        !Array.isArray(frontmatter)
+      ) {
+        const fm = frontmatter as Record<string, unknown>;
+        if (typeof fm["slug"] === "string") {
+          frontmatterSlug = fm["slug"];
         }
-      } catch {
-        // already handled by lintFile
       }
 
       const slug = deriveSlug(basename(filePath), frontmatterSlug);
       const existing = slugMap.get(slug);
       if (existing !== undefined) {
-        const dupError: LintError = {
-          path: relPath,
-          kind: "duplicate-slug",
-          message: `duplicate slug "${slug}" — also used by ${existing}`,
-        };
-        allErrors.push(dupError);
+        // Both files collide. Flag both as errors AND update both file
+        // statuses so --report and --json output stay consistent. (copilot #45)
+        const currentMsg = `duplicate slug "${slug}" — also used by ${existing}`;
+        const existingMsg = `duplicate slug "${slug}" — also used by ${relPath}`;
 
-        // Also flag the first file with the dup error if not already
-        const firstDupError: LintError = {
-          path: existing,
-          kind: "duplicate-slug",
-          message: `duplicate slug "${slug}" — also used by ${relPath}`,
-        };
-        allErrors.push(firstDupError);
+        allErrors.push({ path: relPath, kind: "duplicate-slug", message: currentMsg });
+        allErrors.push({ path: existing, kind: "duplicate-slug", message: existingMsg });
 
-        // Mark the current file as error
-        const idx = fileResults.findIndex((r) => r.path === relPath);
-        if (idx !== -1) {
-          fileResults[idx] = {
+        const currentIdx = fileResults.findIndex((r) => r.path === relPath);
+        if (currentIdx !== -1) {
+          fileResults[currentIdx] = {
             path: relPath,
             status: "error",
-            reason: dupError.message,
+            reason: currentMsg,
+          };
+        }
+
+        const existingIdx = fileResults.findIndex((r) => r.path === existing);
+        if (existingIdx !== -1) {
+          fileResults[existingIdx] = {
+            path: existing,
+            status: "error",
+            reason: existingMsg,
           };
         }
       } else {
@@ -312,15 +385,15 @@ function lintVault(vaultPath: string): LintOutput {
 
 // ── CLI entrypoint ────────────────────────────────────────────────────────────
 
+type ParsedArgs =
+  | { kind: "ok"; vaultPath: string; report: boolean; json: boolean }
+  | { kind: "error"; message: string };
+
 /**
- * Parses CLI args. Returns { vaultPath, report, json }.
- * Exits with usage message on bad args.
+ * Parses CLI args. Returns a tagged result instead of calling process.exit
+ * — keeps `main` testable without `process.exit` mocking. (gemini #45)
  */
-function parseArgs(argv: string[]): {
-  vaultPath: string;
-  report: boolean;
-  json: boolean;
-} {
+function parseArgs(argv: string[]): ParsedArgs {
   const args = argv.slice(2); // drop node + script path
   let report = false;
   let json = false;
@@ -332,22 +405,20 @@ function parseArgs(argv: string[]): {
     } else if (arg === "--json") {
       json = true;
     } else if (arg.startsWith("-")) {
-      process.stderr.write(`Unknown flag: ${arg}\n`);
-      process.stderr.write(
-        "Usage: vault-lint [--report] [--json] <vault-path>\n",
-      );
-      process.exit(1);
+      return { kind: "error", message: `Unknown flag: ${arg}` };
     } else {
       positional.push(arg);
     }
   }
 
   if (positional.length !== 1) {
-    process.stderr.write("Usage: vault-lint [--report] [--json] <vault-path>\n");
-    process.exit(1);
+    return {
+      kind: "error",
+      message: "Usage: vault-lint [--report] [--json] <vault-path>",
+    };
   }
 
-  return { vaultPath: positional[0], report, json };
+  return { kind: "ok", vaultPath: positional[0], report, json };
 }
 
 /**
@@ -355,7 +426,17 @@ function parseArgs(argv: string[]): {
  * Exported so tests can call it with synthetic argv and capture exit code.
  */
 export function main(argv: string[]): number {
-  const { vaultPath, report, json } = parseArgs(argv);
+  const parsed = parseArgs(argv);
+  if (parsed.kind === "error") {
+    process.stderr.write(parsed.message + "\n");
+    if (!parsed.message.startsWith("Usage:")) {
+      process.stderr.write(
+        "Usage: vault-lint [--report] [--json] <vault-path>\n",
+      );
+    }
+    return 1;
+  }
+  const { vaultPath, report, json } = parsed;
 
   const output = lintVault(vaultPath);
   const { summary, files, errors } = output;

--- a/test/vault/vault-lint.test.ts
+++ b/test/vault/vault-lint.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Tests for scripts/vault-lint.ts
+ *
+ * Strategy: we import main() directly (the function is pure over argv and
+ * returns an exit code). We swap process.stdout.write / process.stderr.write
+ * to capture output, and restore them after each test. We create a temporary
+ * fixture directory for each test scenario via Node's fs module.
+ *
+ * Coverage:
+ *   - Clean vault → exit 0
+ *   - Duplicate slug → exit 1 with paths in output
+ *   - Malformed-public note → exit 1
+ *   - --report lists every file with status
+ *   - --json emits valid JSON matching schema; no human text on stdout
+ *   - Pre-commit hook scenario: exit code propagates correctly
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { main } from "../../scripts/vault-lint.js";
+
+// ── Capture helpers ───────────────────────────────────────────────────────────
+
+interface Captured {
+  stdout: string;
+  stderr: string;
+}
+
+function withCapture(fn: () => number): { code: number } & Captured {
+  let stdout = "";
+  let stderr = "";
+
+  const origStdout = process.stdout.write.bind(process.stdout);
+  const origStderr = process.stderr.write.bind(process.stderr);
+
+  process.stdout.write = (chunk: string | Uint8Array): boolean => {
+    stdout += chunk.toString();
+    return true;
+  };
+  process.stderr.write = (chunk: string | Uint8Array): boolean => {
+    stderr += chunk.toString();
+    return true;
+  };
+
+  let code: number;
+  try {
+    code = fn();
+  } finally {
+    process.stdout.write = origStdout;
+    process.stderr.write = origStderr;
+  }
+
+  return { code, stdout, stderr };
+}
+
+// ── Fixture builder ───────────────────────────────────────────────────────────
+
+const VALID_PUBLIC = (title = "Hello World", date = "2026-05-10") => `---
+title: ${title}
+date: ${date}
+visibility: public
+---
+
+Body text.
+`;
+
+const VALID_PRIVATE = `---
+title: Private Note
+date: 2026-05-09
+visibility: private
+---
+
+Private body.
+`;
+
+const NO_VISIBILITY = `---
+title: No Visibility
+date: 2026-05-08
+---
+
+No visibility field — defaults to private.
+`;
+
+const MALFORMED_YAML = `---
+title: Malformed YAML
+date: this is not a date
+visibility public
+---
+
+Bad frontmatter (missing colon on visibility).
+`;
+
+let tmpDir: string;
+
+function makeVault(notes: Record<string, string>): string {
+  const vaultDir = join(tmpDir, "vault");
+  const notesDir = join(vaultDir, "notes");
+  mkdirSync(notesDir, { recursive: true });
+  for (const [name, content] of Object.entries(notes)) {
+    writeFileSync(join(notesDir, name), content, "utf-8");
+  }
+  return vaultDir;
+}
+
+// ── Test setup ────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  tmpDir = join(
+    tmpdir(),
+    `vault-lint-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("vault-lint CLI", () => {
+  describe("clean vault", () => {
+    it("exits 0 when all notes are valid", () => {
+      const vault = makeVault({
+        "hello-world.md": VALID_PUBLIC(),
+        "private.md": VALID_PRIVATE,
+        "no-vis.md": NO_VISIBILITY,
+      });
+
+      const { code } = withCapture(() =>
+        main(["node", "vault-lint.ts", vault]),
+      );
+
+      expect(code).toBe(0);
+    });
+
+    it("emits no errors to stderr on clean vault (default mode)", () => {
+      const vault = makeVault({
+        "hello-world.md": VALID_PUBLIC(),
+      });
+
+      const { code, stderr } = withCapture(() =>
+        main(["node", "vault-lint.ts", vault]),
+      );
+
+      expect(code).toBe(0);
+      expect(stderr).not.toMatch(/\[schema\]|\[yaml\]|\[duplicate-slug\]/);
+    });
+  });
+
+  describe("duplicate slug detection", () => {
+    it("exits 1 when two files produce the same slug", () => {
+      const vault = makeVault({
+        "hello-world.md": VALID_PUBLIC("Hello World"),
+        // 'Hello World.md' → same slug as 'hello-world.md'
+        "Hello World.md": VALID_PUBLIC("Hello World Dupe"),
+      });
+
+      const { code } = withCapture(() =>
+        main(["node", "vault-lint.ts", vault]),
+      );
+
+      expect(code).toBe(1);
+    });
+
+    it("reports both colliding paths in stderr output", () => {
+      const vault = makeVault({
+        "hello-world.md": VALID_PUBLIC("Hello World"),
+        "Hello World.md": VALID_PUBLIC("Hello World Dupe"),
+      });
+
+      const { stderr } = withCapture(() =>
+        main(["node", "vault-lint.ts", vault]),
+      );
+
+      expect(stderr).toMatch(/duplicate-slug|duplicate slug/i);
+      expect(stderr).toMatch(/hello-world/);
+    });
+
+    it("exits 1 when frontmatter slug override collides with another file", () => {
+      const withSlugOverride = `---
+title: My Note
+date: 2026-05-10
+visibility: private
+slug: hello-world
+---
+
+Body.
+`;
+      const vault = makeVault({
+        "hello-world.md": VALID_PUBLIC("Hello World"),
+        "other-note.md": withSlugOverride,
+      });
+
+      const { code } = withCapture(() =>
+        main(["node", "vault-lint.ts", vault]),
+      );
+
+      expect(code).toBe(1);
+    });
+  });
+
+  describe("malformed notes", () => {
+    it("exits 1 on YAML parse error", () => {
+      const vault = makeVault({
+        "good.md": VALID_PUBLIC(),
+        "malformed.md": MALFORMED_YAML,
+      });
+
+      const { code } = withCapture(() =>
+        main(["node", "vault-lint.ts", vault]),
+      );
+
+      expect(code).toBe(1);
+    });
+
+    it("reports yaml error kind in stderr", () => {
+      const vault = makeVault({
+        "malformed.md": MALFORMED_YAML,
+      });
+
+      const { stderr } = withCapture(() =>
+        main(["node", "vault-lint.ts", vault]),
+      );
+
+      expect(stderr).toMatch(/\[yaml\]/);
+    });
+
+    it("does not crash on a file with missing required fields (treats as private)", () => {
+      const missingTitle = `---
+date: 2026-05-10
+visibility: public
+---
+
+No title field — schema should fail, resolves to private.
+`;
+      const vault = makeVault({
+        "no-title.md": missingTitle,
+      });
+
+      const { code } = withCapture(() =>
+        main(["node", "vault-lint.ts", vault]),
+      );
+
+      // Missing title on public note → schema error → exit 1
+      // (resolveVisibility returns 'private' since schema fails → no error from lint)
+      // Actually: resolveVisibility uses safeParse; missing title → returns private → no error
+      // So exit 0 (it's just treated as private)
+      expect(code).toBe(0);
+    });
+  });
+
+  describe("--report flag", () => {
+    it("lists every file with its status", () => {
+      const vault = makeVault({
+        "public-note.md": VALID_PUBLIC(),
+        "private-note.md": VALID_PRIVATE,
+        "no-vis.md": NO_VISIBILITY,
+      });
+
+      const { stderr } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--report", vault]),
+      );
+
+      expect(stderr).toMatch(/public-note\.md/);
+      expect(stderr).toMatch(/private-note\.md/);
+      expect(stderr).toMatch(/no-vis\.md/);
+    });
+
+    it("marks public files with [public] tag", () => {
+      const vault = makeVault({
+        "my-post.md": VALID_PUBLIC(),
+      });
+
+      const { stderr } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--report", vault]),
+      );
+
+      expect(stderr).toMatch(/\[public\]/i);
+      expect(stderr).toMatch(/my-post\.md/);
+    });
+
+    it("marks private files with [private] tag and includes reason", () => {
+      const vault = makeVault({
+        "private.md": VALID_PRIVATE,
+      });
+
+      const { stderr } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--report", vault]),
+      );
+
+      expect(stderr).toMatch(/\[private\]/i);
+      expect(stderr).toMatch(/private\.md/);
+    });
+
+    it("exits 0 on clean vault even with --report", () => {
+      const vault = makeVault({
+        "post.md": VALID_PUBLIC(),
+      });
+
+      const { code } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--report", vault]),
+      );
+
+      expect(code).toBe(0);
+    });
+
+    it("exits 1 and reports errors in --report mode", () => {
+      const vault = makeVault({
+        // "hello-world.md" and "Hello World.md" both derive slug "hello-world"
+        "hello-world.md": VALID_PUBLIC("Note A"),
+        "Hello World.md": VALID_PUBLIC("Note A Dup"),
+      });
+
+      const { code, stderr } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--report", vault]),
+      );
+
+      expect(code).toBe(1);
+      expect(stderr).toMatch(/duplicate/i);
+    });
+  });
+
+  describe("--json flag", () => {
+    it("emits valid JSON to stdout", () => {
+      const vault = makeVault({
+        "hello.md": VALID_PUBLIC(),
+        "private.md": VALID_PRIVATE,
+      });
+
+      const { stdout } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--json", vault]),
+      );
+
+      const parsed = JSON.parse(stdout) as unknown;
+      expect(parsed).toBeTruthy();
+    });
+
+    it("JSON output matches the expected schema shape", () => {
+      const vault = makeVault({
+        "hello.md": VALID_PUBLIC(),
+        "private.md": VALID_PRIVATE,
+      });
+
+      const { stdout } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--json", vault]),
+      );
+
+      const result = JSON.parse(stdout) as {
+        summary: { walked: number; public: number; private: number; errors: number };
+        files: Array<{ path: string; status: string; reason?: string }>;
+        errors: Array<{ path: string; kind: string; message: string }>;
+      };
+
+      expect(typeof result.summary.walked).toBe("number");
+      expect(typeof result.summary.public).toBe("number");
+      expect(typeof result.summary.private).toBe("number");
+      expect(typeof result.summary.errors).toBe("number");
+      expect(Array.isArray(result.files)).toBe(true);
+      expect(Array.isArray(result.errors)).toBe(true);
+
+      // Verify a file entry shape
+      const publicFile = result.files.find((f) => f.path.includes("hello"));
+      expect(publicFile).toBeDefined();
+      expect(publicFile?.status).toBe("public");
+
+      const privateFile = result.files.find((f) => f.path.includes("private"));
+      expect(privateFile).toBeDefined();
+      expect(privateFile?.status).toBe("private");
+    });
+
+    it("emits no human-readable text to stdout in --json mode", () => {
+      const vault = makeVault({
+        "hello.md": VALID_PUBLIC(),
+      });
+
+      const { stdout } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--json", vault]),
+      );
+
+      // The only stdout content should be parseable JSON
+      expect(() => JSON.parse(stdout)).not.toThrow();
+      // Verify it's not wrapped in extra prose
+      expect(stdout.trim()).toMatch(/^\{/);
+    });
+
+    it("summary counts match actual files", () => {
+      const vault = makeVault({
+        "pub1.md": VALID_PUBLIC("Note 1"),
+        "pub2.md": VALID_PUBLIC("Note 2"),
+        "priv.md": VALID_PRIVATE,
+      });
+
+      const { stdout } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--json", vault]),
+      );
+
+      const result = JSON.parse(stdout) as {
+        summary: { walked: number; public: number; private: number; errors: number };
+        files: Array<{ path: string; status: string }>;
+        errors: Array<unknown>;
+      };
+
+      expect(result.summary.walked).toBe(3);
+      expect(result.summary.public).toBe(2);
+      expect(result.summary.private).toBe(1);
+      expect(result.summary.errors).toBe(0);
+    });
+
+    it("exits 1 and reports errors in JSON", () => {
+      const vault = makeVault({
+        // "hello-world.md" and "Hello World.md" both derive slug "hello-world"
+        "hello-world.md": VALID_PUBLIC("Note A"),
+        "Hello World.md": VALID_PUBLIC("Note A Dup"),
+      });
+
+      const { code, stdout } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--json", vault]),
+      );
+
+      const result = JSON.parse(stdout) as {
+        errors: Array<{ kind: string; path: string; message: string }>;
+      };
+
+      expect(code).toBe(1);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it("does not emit human-readable output to stderr in --json mode", () => {
+      const vault = makeVault({
+        "hello.md": VALID_PUBLIC(),
+      });
+
+      const { stderr } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--json", vault]),
+      );
+
+      // No human-readable summary lines in stderr for json mode
+      expect(stderr).not.toMatch(/vault-lint:/);
+      expect(stderr).not.toMatch(/walked/);
+    });
+  });
+
+  describe("hidden directory skipping", () => {
+    it("does not walk .obsidian or .trash directories", () => {
+      const vaultDir = join(tmpDir, "vault");
+      const notesDir = join(vaultDir, "notes");
+      const obsidianDir = join(vaultDir, ".obsidian");
+      const trashDir = join(vaultDir, ".trash");
+
+      mkdirSync(notesDir, { recursive: true });
+      mkdirSync(obsidianDir, { recursive: true });
+      mkdirSync(trashDir, { recursive: true });
+
+      writeFileSync(join(notesDir, "public.md"), VALID_PUBLIC(), "utf-8");
+      // These malformed files in hidden dirs should NOT be walked
+      writeFileSync(join(obsidianDir, "settings.md"), MALFORMED_YAML, "utf-8");
+      writeFileSync(join(trashDir, "deleted.md"), MALFORMED_YAML, "utf-8");
+
+      const { code, stdout } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--json", vaultDir]),
+      );
+
+      // Only the one note in notes/ should be walked; no errors from hidden dirs
+      const result = JSON.parse(stdout) as {
+        summary: { walked: number; errors: number };
+      };
+
+      expect(code).toBe(0);
+      expect(result.summary.walked).toBe(1);
+    });
+  });
+
+  describe("pre-commit hook scenario", () => {
+    it("exit code propagates correctly for CI use", () => {
+      const cleanVault = makeVault({
+        "note.md": VALID_PUBLIC(),
+      });
+
+      const { code: cleanCode } = withCapture(() =>
+        main(["node", "vault-lint.ts", cleanVault]),
+      );
+      expect(cleanCode).toBe(0);
+
+      const dupVault = makeVault({
+        // "hello-world.md" and "Hello World.md" both derive slug "hello-world"
+        "hello-world.md": VALID_PUBLIC("Note"),
+        "Hello World.md": VALID_PUBLIC("Note Dup"),
+      });
+
+      const { code: errCode } = withCapture(() =>
+        main(["node", "vault-lint.ts", dupVault]),
+      );
+      expect(errCode).toBe(1);
+    });
+  });
+
+  describe("static fixture vault", () => {
+    it("lints the __fixtures__/vault directory cleanly", () => {
+      const fixtureVault = join(
+        process.cwd(),
+        "__fixtures__",
+        "vault",
+      );
+
+      const { code } = withCapture(() =>
+        main(["node", "vault-lint.ts", fixtureVault]),
+      );
+
+      expect(code).toBe(0);
+    });
+  });
+});

--- a/test/vault/vault-lint.test.ts
+++ b/test/vault/vault-lint.test.ts
@@ -1,18 +1,23 @@
 /**
  * Tests for scripts/vault-lint.ts
  *
- * Strategy: we import main() directly (the function is pure over argv and
- * returns an exit code). We swap process.stdout.write / process.stderr.write
- * to capture output, and restore them after each test. We create a temporary
- * fixture directory for each test scenario via Node's fs module.
+ * Strategy: import main() directly. After PR #45 review fixes, main() is
+ * pure over argv — parseArgs returns a tagged result rather than calling
+ * process.exit — so tests assert on the return value without exit mocking.
+ *
+ * Stdout/stderr swapped per test to capture output; temp fixture dir per
+ * scenario via Node's fs.
  *
  * Coverage:
  *   - Clean vault → exit 0
- *   - Duplicate slug → exit 1 with paths in output
- *   - Malformed-public note → exit 1
- *   - --report lists every file with status
- *   - --json emits valid JSON matching schema; no human text on stdout
+ *   - Duplicate slug → exit 1; BOTH colliding paths flagged as errors
+ *   - Malformed YAML (missing closing fence) → exit 1, kind: yaml
+ *   - Note resolving to private (missing visibility) → status=private, exit 0
+ *   - --report lists every file with status + reason
+ *   - --json emits valid JSON to stdout only; no human text on stdout
  *   - Pre-commit hook scenario: exit code propagates correctly
+ *   - Bad CLI args → exit 1 with usage on stderr (no process.exit)
+ *   - Walk failure (non-existent / not-a-directory) → exit 1, kind: io
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
@@ -510,6 +515,101 @@ No title field — schema should fail, resolves to private.
       );
 
       expect(code).toBe(0);
+    });
+  });
+
+  // ── Regressions / bot review fixes ─────────────────────────────────────────
+
+  describe("regressions (PR #45 review)", () => {
+    it("rejects opening --- without closing fence as YAML error (copilot #45)", () => {
+      const v = makeVault({});
+      writeFileSync(
+        join(v, "broken.md"),
+        "---\ntitle: Broken\nvisibility: public\n",
+      );
+      const { code, stderr } = withCapture(() =>
+        main(["node", "vault-lint.ts", v]),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toMatch(/yaml/i);
+    });
+
+    it("flags BOTH files in a duplicate-slug collision (copilot #45)", () => {
+      const v = makeVault({});
+      writeFileSync(
+        join(v, "hello.md"),
+        "---\ntitle: A\ndate: 2026-05-10\nvisibility: public\nslug: shared\n---\n",
+      );
+      writeFileSync(
+        join(v, "world.md"),
+        "---\ntitle: B\ndate: 2026-05-11\nvisibility: public\nslug: shared\n---\n",
+      );
+      const { code, stdout } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--json", v]),
+      );
+      expect(code).toBe(1);
+      const out = JSON.parse(stdout) as {
+        files: { path: string; status: string }[];
+        errors: { path: string; kind: string }[];
+      };
+      const errPaths = new Set(
+        out.errors
+          .filter((e) => e.kind === "duplicate-slug")
+          .map((e) => e.path),
+      );
+      expect(errPaths.has("hello.md")).toBe(true);
+      expect(errPaths.has("world.md")).toBe(true);
+      const fileStatuses = Object.fromEntries(
+        out.files.map((f) => [f.path, f.status]),
+      );
+      expect(fileStatuses["hello.md"]).toBe("error");
+      expect(fileStatuses["world.md"]).toBe("error");
+    });
+
+    it("treats non-existent vault path as walk error, not silent OK (copilot #45)", () => {
+      const ghostPath = join(tmpdir(), "vault-lint-ghost-" + Date.now());
+      const { code, stderr } = withCapture(() =>
+        main(["node", "vault-lint.ts", ghostPath]),
+      );
+      expect(code).toBe(1);
+      expect(stderr.toLowerCase()).toMatch(/io|walk|directory|enoent/);
+    });
+
+    it("returns exit 1 (not process.exit) on bad args (gemini #45)", () => {
+      const { code, stderr } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--unknown-flag"]),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toMatch(/Unknown flag|Usage/);
+    });
+
+    it("skips symlinks (matches lib/vault/walk.ts policy, copilot #45)", async () => {
+      const { symlinkSync, existsSync } = await import("fs");
+      const v = makeVault({});
+      writeFileSync(
+        join(v, "real.md"),
+        "---\ntitle: Real\ndate: 2026-05-10\nvisibility: public\n---\n",
+      );
+      // Create a symlink pointing to a target that exists
+      try {
+        symlinkSync(
+          join(v, "real.md"),
+          join(v, "symlink-to-real.md"),
+        );
+      } catch {
+        // Skip on platforms / FS that don't support symlinks
+        return;
+      }
+      if (!existsSync(join(v, "symlink-to-real.md"))) return;
+      const { code, stdout } = withCapture(() =>
+        main(["node", "vault-lint.ts", "--json", v]),
+      );
+      expect(code).toBe(0);
+      const out = JSON.parse(stdout) as {
+        files: { path: string }[];
+      };
+      // Only 'real.md' should appear; the symlink must be skipped
+      expect(out.files.map((f) => f.path)).toEqual(["real.md"]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- `scripts/vault-lint.ts` — walks vault, runs schema + slug-uniqueness checks; exits 0 on clean, 1 on any error
- `--report` flag: structured stderr listing every walked file with resolved visibility + reason if not public (P23 debugging tool)
- `--json` flag: machine-readable stdout output for pre-commit hooks; matches typed schema `{ summary, files[], errors[] }`
- `test/vault/vault-lint.test.ts` — 22 tests: clean vault, duplicate slug detection, YAML errors, --report, --json, hidden dir skipping, pre-commit exit code propagation
- `__fixtures__/vault/` — synthetic fixture vault for tests

## Evidence: `--report` output against `dy-journal`

```
vault-lint report — walked 8 files
  public: 2  private: 5  errors: 1

  [private]  AUTHORING.md  — schema error: title: Required
  [private]  README.md  — schema error: title: Required
  [public]   notes/2026-05-09-typed-not-day.md
  [public]   notes/2026-05-10-hello-world.md
  [private]  notes/draft-rough-thoughts.md  — schema error: visibility: Invalid enum value. Expected 'public' | 'private', received 'draft'
  [error]    notes/malformed-frontmatter.md  — yaml parse error: can not read a block mapping entry; a multiline key may not be an implicit key
  [private]  notes/private-q3-planning.md  — no visibility field (defaults to private)
  [private]  templates/note.md  — schema error: date: date must be YYYY-MM-DD

Errors:
  [yaml] notes/malformed-frontmatter.md: YAML parse error: ...
```

Observations:
- 2 public notes correctly identified
- `.obsidian/` and `.trash/` NOT walked (hidden dir skip works)
- `malformed-frontmatter.md` flagged as `[yaml]` error but does NOT crash
- `draft-rough-thoughts.md` caught as private (visibility=draft not in enum)
- `templates/note.md` caught as private (template date placeholder)

## Test plan

- [x] `npm run test:run` — 111 tests, all pass
- [x] `npm run lint` — no issues
- [x] `npm run typecheck` — clean
- [x] `npm run vault-lint -- __fixtures__/vault` — exits 0, 3 files walked
- [x] `npm run vault-lint -- --report dy-journal` — correct per-file output (above)
- [x] `npm run vault-lint -- --json dy-journal` — valid JSON matching schema

Stacks on #42.

Refs #30 #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)