### PR TITLE
feat(vault): walk + local + github adapters (#33)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@
 
 # Where to read the Obsidian vault from.
 #   local  — read from VAULT_PATH on disk (Slice 0 dev default)
-#   github — clone via Tarball API using VAULT_REPO_URL + VAULT_GITHUB_TOKEN
+#   github — download + extract a tarball via the GitHub Tarball API using
+#           VAULT_REPO_URL + VAULT_GITHUB_TOKEN (no on-disk clone)
 VAULT_SOURCE=local
 
 # Absolute path or path relative to this repo's root. Required when

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Vault adapter — Slice 0
+
+# Where to read the Obsidian vault from.
+#   local  — read from VAULT_PATH on disk (Slice 0 dev default)
+#   github — clone via Tarball API using VAULT_REPO_URL + VAULT_GITHUB_TOKEN
+VAULT_SOURCE=local
+
+# Absolute path or path relative to this repo's root. Required when
+# VAULT_SOURCE=local. In NODE_ENV=production this MUST be set explicitly
+# (no fixture fallback).
+VAULT_PATH=/absolute/path/to/dy-journal
+
+# Vault adapter — Slice 1+ (uncomment when shipping the GitHub adapter and authed flows)
+
+# VAULT_REPO_URL=https://github.com/donovan-yohan/dy-journal
+# VAULT_GITHUB_TOKEN=github_pat_...     # fine-grained PAT, dy-journal only, Contents:read + Metadata:read
+# OWNER_GITHUB_LOGIN=donovan-yohan      # case-insensitive comparison in signIn callback
+# VERCEL_DEPLOY_HOOK_URL=https://api.vercel.com/v1/integrations/deploy/...
+# VAULT_WEBHOOK_SECRET=long-random-string  # `openssl rand -hex 32`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,11 @@ ticket #38) for the operator-side contract.
   Any change here MUST extend the table, not relax it.
 - **`lib/vault/schema.ts`** — never relax `default('private')`, never remove
   `passthrough()`, never change the `visibility` enum.
-- **`lib/vault/walk.ts`** — never weaken the allowlist
-  (`.obsidian/`, `.trash/`, `.git/`, `.github/`, `node_modules/`, `templates/`),
-  never change `followSymbolicLinks: false`.
+- **`lib/vault/walk.ts`** — never weaken the path **ignore-list** — directories
+  that MUST be excluded from the walk: `.obsidian/`, `.trash/`, `.git/`,
+  `.github/`, `node_modules/`, `templates/`. (The allowed-glob is `**/*.md`;
+  these directories are subtracted from it.) Never change
+  `followSymbolicLinks: false`.
 - **`schema.ts` and `fail-closed.ts` are co-owned**. Do not split them across
   parallel worktrees. They must change atomically.
 - **Public route imports MUST come from `lib/vault/index.ts`**. Never import

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,21 @@ This is Donovan Yohan's portfolio site. It uses Next.js Pages Router, React, sty
 - Keep generated folders (`.next`, `out`, `coverage`, `node_modules`) out of edits.
 - Future design-system work should align content and layout to the dot-grid/sketchbook direction in `DESIGN.md`.
 
-## Vault adapter — load-bearing privacy code
+## Vault adapter — load-bearing privacy code (forward-looking)
+
+> **Note:** This section describes the vault adapter design that lands across
+> stacked PRs in epic #30. As of this commit, only AGENTS.md + API_CONTRACT.md
+> exist. The files referenced below (`lib/vault/**`, `test/leak.test.ts`,
+> `test/resolveVisibility.test.ts`, `npm run vault-lint`, the
+> `import/no-restricted-paths` ESLint config, the `eslint-disable` CI grep) ship
+> in tickets #32–#38. This guide is in place first so nightshift sub-agents
+> working on those tickets follow the contract from line one.
 
 Files in `lib/vault/**` and the leak test in `test/leak.test.ts` are the privacy
 boundary of donovanyohan.com. The vault data source is the private GitHub repo
 [`donovan-yohan/dy-journal`](https://github.com/donovan-yohan/dy-journal). See
-`API_CONTRACT.md` for the data shape and `VAULT.md` (in this repo, ships with
-ticket #38) for the operator-side contract.
+`API_CONTRACT.md` for the data shape and `VAULT.md` (lands with ticket #38) for
+the operator-side contract.
 
 ### Hard rules — do NOT modify without reading API_CONTRACT.md and VAULT.md
 
@@ -51,13 +59,32 @@ ticket #38) for the operator-side contract.
 - **No module-init side effects** in `lib/vault/*`. No I/O, no env validation,
   no throws at import time. Pure imports only.
 
-### Verification commands
+### Verification commands (available as tickets land)
 
+Today (post #31):
 ```bash
-npm test                              # vitest suite incl. leak test + resolveVisibility table
-npm run vault-lint __fixtures__/vault # checks fixture vault
-npm run vault-lint -- --report ../dy-journal  # Donovan's daily check
 npm run check                         # full lint + typecheck + tests + build
+npm test                              # vitest smoke tests
+```
+
+Available after #32 ships:
+```bash
+npm test                              # adds resolveVisibility table tests
+```
+
+Available after #36 ships:
+```bash
+npm run vault-lint -- __fixtures__/vault                # fixture sanity check
+npm run vault-lint -- --report <vault-path>             # daily debug
+```
+
+Replace `<vault-path>` with the absolute path to your Obsidian vault — there's
+no canonical sibling layout assumption. Donovan's local layout is
+`~/Documents/Programs/personal/dy-journal`; forkers' layouts vary.
+
+Available after #37 ships:
+```bash
+npm test                              # adds leak test as a CI gate
 ```
 
 ### Worktree etiquette (nightshift orchestration)

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -1,11 +1,22 @@
-# API_CONTRACT.md — Vault → Frontend
+# API_CONTRACT.md — Vault → Frontend (proposed)
 
 The shape and guarantees the vault adapter exposes for the bullet-journal /
 notebook UI to build against. This is the load-bearing contract.
 
-> **Source of truth:** `lib/vault/schema.ts` (Zod) is canonical; this doc is the
-> human-readable mirror. If they ever disagree, the code wins; raise a PR to fix
-> this doc.
+> **Status:** PROPOSED. The implementation lands across the stacked PRs in
+> epic #30:
+> - `lib/vault/schema.ts`, `lib/vault/index.ts` — ticket #32 / PR #42
+> - `lib/vault/adapter-local.ts`, `adapter-github.ts`, `walk.ts` — ticket #33
+> - `lib/vault/render.ts` — ticket #34
+> - `pages/writing/index.tsx`, `[slug].tsx` — ticket #35
+>
+> **Source of truth (once the code lands):** `lib/vault/schema.ts` (Zod) is
+> canonical; this doc is the human-readable mirror. If they ever disagree, the
+> code wins; raise a PR to fix this doc.
+>
+> **`import/no-restricted-paths` enforcement:** the ESLint rule + plugin lands
+> with #33. Until then this contract describes the intended boundary; CI does
+> not yet enforce it.
 
 ## Public types
 
@@ -235,7 +246,8 @@ class VaultParseError extends Error {
 ---
 
 If you're authoring notes (not building the frontend), see
-[dy-journal/AUTHORING.md](https://github.com/donovan-yohan/dy-journal/blob/master/AUTHORING.md).
+[dy-journal/AUTHORING.md](https://github.com/donovan-yohan/dy-journal/blob/HEAD/AUTHORING.md)
+(branch-agnostic link).
 If you're building the privacy adapter, see
 [VAULT.md](./VAULT.md) (lands with ticket #38) and
 [AGENTS.md](./AGENTS.md) for nightshift constraints.

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -49,6 +49,15 @@ export interface VaultAdapter {
   // Slice 1+ adds:
   // getAllNotes(): Promise<VaultNote[]>;  // authed-only
 }
+
+export interface VaultConfig {
+  source: 'local' | 'github';
+  path?: string;             // when source === 'local'
+  repoUrl?: string;          // when source === 'github' (Slice 1+)
+  token?: string;            // when source === 'github' (Slice 1+)
+  // Resolved by getVaultConfig() based on env vars; throws on missing
+  // required values when NODE_ENV === 'production'.
+}
 ```
 
 ## Public API surface
@@ -62,14 +71,26 @@ import type { VaultNote } from './schema';
  * Returns all notes from the configured vault that resolved to `public`
  * via fail-closed visibility. Sorted by `frontmatter.date` descending.
  *
- * Throws DuplicateSlugError if two notes share a slug.
- * Throws if VAULT_PATH (Slice 0) or VAULT_REPO_URL+TOKEN (Slice 1) is missing
- *   in production (NODE_ENV=production).
+ * Internally memoized: the first call walks + parses the vault; subsequent
+ * calls within the same Node process return the cached result. This keeps
+ * getStaticPaths + getStaticProps amortized to O(N) total, not O(N²).
+ *
+ * Throws DuplicateSlugError if any notes share a slug.
+ * Throws VaultConfigError if VAULT_PATH (Slice 0) or VAULT_REPO_URL+TOKEN
+ *   (Slice 1) is missing in NODE_ENV=production.
  *
  * Safe to call from getStaticProps / getStaticPaths.
  * NEVER call from public client code.
  */
 export function getPublicNotes(): Promise<VaultNote[]>;
+
+/**
+ * Convenience for /writing/[slug] getStaticProps. Equivalent to
+ * `(await getPublicNotes()).find(n => n.slug === slug) ?? null`, but
+ * shares the memoized cache with getPublicNotes() so per-slug lookups
+ * are O(1) after the first walk.
+ */
+export function getNoteBySlug(slug: string): Promise<VaultNote | null>;
 
 /**
  * Throws on missing required env vars. Called inside getStaticPaths/Props
@@ -185,9 +206,9 @@ Vercel keeps every deploy in its history; rollback = re-promote a prior deploy
 
 ```ts
 class DuplicateSlugError extends Error {
-  paths: [string, string];   // both colliding files
+  paths: string[];           // all colliding files (≥2)
   slug: string;
-  resolution: 'derived' | 'frontmatter';  // how each got the slug
+  resolutions: Array<'derived' | 'frontmatter'>; // parallel to paths
 }
 
 class VaultConfigError extends Error {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # donovanyohan
 
-Portfolio website.
+Portfolio website. Please hire me.
 
-Please hire me.
+## Vault adapter
+
+Content for `/writing` comes from a private Obsidian vault
+([dy-journal](https://github.com/donovan-yohan/dy-journal)). See
+[VAULT.md](./VAULT.md) for the operator + setup guide,
+[API_CONTRACT.md](./API_CONTRACT.md) for the data shape the frontend builds against,
+and [AGENTS.md](./AGENTS.md) for AI-editing constraints on `lib/vault/**`.

--- a/VAULT.md
+++ b/VAULT.md
@@ -233,8 +233,8 @@ Output looks like:
 [private] notes/draft-rough-thoughts.md       (visibility: draft → not public)
 [private] notes/malformed-frontmatter.md      (yaml parse error)
 [error] notes/duplicate-slug.md               (collides with notes/other.md)
-[ignored] .trash/old-public.md                (excluded by walk allowlist)
-[ignored] .obsidian/workspace.json            (excluded by walk allowlist)
+[ignored] .trash/old-public.md                (excluded by walk ignore-list)
+[ignored] .obsidian/workspace.json            (excluded by walk ignore-list)
 
 Summary: 1 public, 3 private, 1 error, 2 ignored
 ```

--- a/VAULT.md
+++ b/VAULT.md
@@ -1,0 +1,335 @@
+# VAULT.md — Vault adapter operator guide
+
+How `donovanyohan.com` reads content from the private Obsidian vault, what
+guarantees the privacy boundary makes, and how to debug when notes don't appear.
+
+> **Audience:** primarily Donovan as the operator + nightshift sub-agents
+> working on `lib/vault/**`. Forkers welcome (the architecture is portable),
+> but kit-friendliness is a bonus, not the primary goal.
+>
+> **Companion docs:**
+> - `AGENTS.md` — load-bearing-files rules for AI editing
+> - `API_CONTRACT.md` — frontend contract (proposed shape)
+> - `dy-journal/AUTHORING.md` — author-side guide for what frontmatter to type
+
+## Architecture in one diagram
+
+```
+┌─────────────────────┐     git push       ┌────────────────────┐
+│  Obsidian (you)     │ ─────────────────▶ │ dy-journal (private │
+│  edits notes        │                    │ GitHub repo)        │
+└─────────────────────┘                    └────────┬────────────┘
+                                                    │
+                                  fine-grained PAT  │  Tarball API
+                                  Contents: read    │  GET /tarball/{ref}
+                                                    ▼
+┌─────────────────────────────────────────────────────────────────┐
+│              donovanyohan (public GitHub repo)                  │
+│                                                                  │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  Build (Vercel)                                            │ │
+│  │                                                             │ │
+│  │  lib/vault/index.ts                                         │ │
+│  │  ├─ getVaultConfig()  — env validation, function-scoped     │ │
+│  │  ├─ getPublicNotes()  — memoized; walk-then-stop-if-private │ │
+│  │  └─ getNoteBySlug()   — uses memoized cache                 │ │
+│  │                                                             │ │
+│  │  ┌─────────────┐    ┌──────────────┐    ┌──────────────┐    │ │
+│  │  │ adapter-    │    │ walk +       │    │ schema +     │    │ │
+│  │  │ local       │ or │ ignore-list  │ →  │ fail-closed  │    │ │
+│  │  │ adapter-    │    │ + symlink    │    │ + slug deriv │    │ │
+│  │  │ github      │    │ rejection    │    │ + render     │    │ │
+│  │  └─────────────┘    └──────────────┘    └──────────────┘    │ │
+│  │                            │                                │ │
+│  │                            ▼                                │ │
+│  │                     leak test (CI gate)                     │ │
+│  │                            │                                │ │
+│  └────────────────────────────┼────────────────────────────────┘ │
+│                               ▼                                  │
+│                       /writing  /writing/[slug]                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Privacy contract — what you can rely on
+
+1. **Default-deny.** `visibility: public` is the only opt-in. Anything else
+   (missing field, typo, malformed YAML, `private`, `draft`) → **private**.
+2. **Walk-then-stop-if-private.** Private notes never have their bodies parsed,
+   sanitized, or have excerpts computed. Build code only touches public bodies.
+3. **Walk ignore-list.** Files under `.obsidian/`, `.trash/`, `.git/`,
+   `.github/`, `node_modules/`, `templates/` are never read. Even a public note
+   inside `.trash/` stays invisible (move it back to `notes/` to publish).
+4. **Symlinks rejected by default.** No `vault/public.md → /etc/passwd`
+   exfiltration vectors.
+5. **Tarball traversal protection.** GitHub Tarball entries with `..`, absolute
+   paths, hardlinks, device entries, or symlinks are rejected during extraction.
+6. **HTML sanitized.** `<script>`, `<iframe>`, `onclick=` etc. stripped from
+   markdown body output by `rehype-sanitize`.
+7. **Wikilinks stripped.** Slice 0 strips all Obsidian wikilink syntax to plain
+   text. Cross-note rendering ships in Slice 2.
+8. **Wikilink-target leak check.** Build fails if a public note's wikilink
+   target resolves to a private slug (would leak existence of private notes).
+9. **No public revision history.** The site renders current `HEAD` only; the
+   build never reads `git log`. Promotion (private → public) is a clean cut.
+10. **Module init is pure.** No I/O, no env validation, no throws at import
+    time. Unrelated portfolio routes never crash on missing vault env.
+11. **Static path mode.** `getStaticPaths` returns `fallback: false`. Unknown
+    slugs 404 cleanly; no on-demand SSR can be tricked into rendering private.
+12. **Fine-grained PAT only.** Token scoped to `dy-journal` only with
+    `Contents: read` + `Metadata: read`. Classic PATs (with broad `repo` scope)
+    are rejected.
+13. **CI leak test.** Every PR is gated by a leak test that walks built
+    artifacts (`.next/server/**`, `.next/static/**/*.{js,map}`,
+    `.next/cache/fetch-cache/**`, `.next/trace`, `_next/data/`, `out/**`,
+    `public/**`) plus HTTP-level checks (request `/sitemap.xml`, `/robots.txt`,
+    `/feed.xml`, `/_next/data/...json`, OG endpoints) for any private fixture
+    string. Includes a positive-control canary so a broken test fails loudly.
+
+## Vault layout
+
+The adapter walks the vault root recursively. Conventions:
+
+```
+dy-journal/                # vault root
+├── README.md              # vault-side readme (about the vault)
+├── AUTHORING.md           # frontmatter cheat-sheet (operator-facing)
+├── notes/                 # public + private notes (walked)
+│   └── *.md
+├── templates/             # Templater templates (NOT walked — P17)
+│   └── note.md
+├── .obsidian/             # workspace config (NOT walked)
+├── .trash/                # soft-deleted (NOT walked)
+├── attachments/           # images etc. (only walked for *.md, so ignored)
+└── .gitignore
+```
+
+## Frontmatter contract
+
+```yaml
+---
+title: My note               # REQUIRED, non-empty string
+date: 2026-05-10             # REQUIRED, YYYY-MM-DD
+visibility: public           # OPT-IN to publish (anything else = private)
+slug: my-note                # OPTIONAL, override derived slug
+preview:                     # OPTIONAL, all sub-fields optional
+  kind: text                 # text | image | quote | embed
+  span: 4                    # 1-12 grid columns
+  accent: yellow             # design-token name (see below)
+  tint: paper                # design-token name
+  headline: Custom card title
+  excerpt: First-paragraph override
+  image: /img/hero.png       # when kind: image
+mood: focused                # arbitrary passthrough — preserved but ignored
+---
+
+Body markdown here.
+```
+
+## Slug rules
+
+- Default: derived from filename (kebab-case, ASCII-only, Unicode/emoji stripped, apostrophes contracted).
+- Override: `frontmatter.slug` matching `/^[a-z0-9][a-z0-9-]*$/`.
+- Build fails on duplicate slugs across the public set (`DuplicateSlugError`).
+- Filenames consisting entirely of non-ASCII (e.g. `🚀🔥🎉.md`) collapse to `''` and resolve to private.
+
+| Filename | Derived slug |
+|---|---|
+| `Hello World.md` | `hello-world` |
+| `2026-05-10 Daily.md` | `2026-05-10-daily` |
+| `What's New?.md` | `whats-new` |
+| `résumé.md` | `resume` |
+| `🚀 Launch.md` | `launch` |
+| `Note (draft).md` | `note-draft` |
+
+## Setup — getting it running locally
+
+### 1. Clone both repos
+
+```bash
+git clone git@github.com:donovan-yohan/donovanyohan.git
+git clone git@github.com:donovan-yohan/dy-journal.git    # private, requires access
+```
+
+### 2. Install deps
+
+```bash
+cd donovanyohan
+npm install
+```
+
+### 3. Generate a fine-grained PAT
+
+GitHub → Settings → Developer settings → Personal access tokens → Fine-grained
+tokens → "Generate new token":
+
+- **Repository access:** Only select repositories → `dy-journal`
+- **Permissions → Repository:** Contents (Read), Metadata (Read)
+- **Expiration:** 90 days (max). Set a calendar reminder to rotate.
+
+⚠️ **Do NOT use a classic PAT.** Classic `repo` scope grants read+write to all
+your private repos — much larger blast radius if leaked.
+
+### 4. Create `.env.local`
+
+```bash
+# Slice 0 (local dev — read straight from disk)
+VAULT_SOURCE=local
+VAULT_PATH=/absolute/path/to/dy-journal
+
+# Slice 1+ (production — uncomment when shipping authed/webhook flows)
+# VAULT_SOURCE=github
+# VAULT_REPO_URL=https://github.com/donovan-yohan/dy-journal
+# VAULT_GITHUB_TOKEN=github_pat_...
+# OWNER_GITHUB_LOGIN=donovan-yohan
+# VERCEL_DEPLOY_HOOK_URL=https://api.vercel.com/v1/integrations/deploy/...
+# VAULT_WEBHOOK_SECRET=long-random-string
+```
+
+`VAULT_PATH` accepts absolute paths or paths relative to the portfolio repo
+root (e.g. `../dy-journal`). Production (`NODE_ENV=production`) requires the
+env vars to be set explicitly — no fixture fallback.
+
+### 5. Run
+
+```bash
+npm run dev
+# → http://localhost:3000/writing renders public notes from VAULT_PATH
+```
+
+## Daily workflow — Donovan
+
+```bash
+# 1. Write a note in Obsidian
+# 2. Save (cmd+s)
+# 3. Commit + push from dy-journal:
+cd ~/Documents/Programs/personal/dy-journal
+git add . && git commit -m "post: hello world" && git push
+
+# 4. Trigger a Vercel deploy manually (Slice 0 has no webhook yet):
+#    Visit Vercel dashboard → donovanyohan → Deployments → "Redeploy"
+#    OR set up Vercel CLI: `vercel --prod`
+
+# 5. Verify live at https://donovanyohan.com/writing
+```
+
+Slice 1 adds the webhook: vault push → automatic rebuild.
+
+## Debugging — "I added a note and it didn't appear"
+
+**Run the vault-lint report.** Single most useful command.
+
+```bash
+cd /path/to/donovanyohan
+npm run vault-lint -- --report /path/to/dy-journal
+```
+
+Output looks like:
+
+```
+[public] notes/2026-05-10-hello-world.md
+[private] notes/private-q3-planning.md       (no visibility field)
+[private] notes/draft-rough-thoughts.md       (visibility: draft → not public)
+[private] notes/malformed-frontmatter.md      (yaml parse error)
+[error] notes/duplicate-slug.md               (collides with notes/other.md)
+[ignored] .trash/old-public.md                (excluded by walk allowlist)
+[ignored] .obsidian/workspace.json            (excluded by walk allowlist)
+
+Summary: 1 public, 3 private, 1 error, 2 ignored
+```
+
+If your note appears as `[private]`:
+
+- Check `visibility` field is exactly `public` (not `Public`, `public `, unquoted YAML treating it as boolean, etc.)
+- Check `title` and `date` are present and well-formed
+- Check the YAML overall — missing colons, bad indentation are common
+
+If your note appears as `[ignored]`:
+
+- It's in `.trash/`, `.obsidian/`, `templates/`, etc. — move it out
+
+If the build fails with `DuplicateSlugError`:
+
+- Two notes share a slug. Either rename one file or set explicit `slug:` in frontmatter to disambiguate.
+
+If the build fails with the leak test:
+
+- A private string (or wikilink to a private slug) made it into a public artifact.
+- Error message names the file path and the leaking string.
+- Fix: edit the public note to not reference private content, OR mark the source private.
+- False positive (legitimate overlap): conservative-by-design — restate the public note's prose.
+
+## Pre-commit hook (recommended)
+
+In `dy-journal/.git/hooks/pre-commit`:
+
+```bash
+#!/bin/sh
+PORTFOLIO_PATH=/Users/donovanyohan/Documents/Programs/personal/donovanyohan
+VAULT_PATH="$(git rev-parse --show-toplevel)"
+cd "$PORTFOLIO_PATH" && npm run vault-lint -- "$VAULT_PATH"
+```
+
+`chmod +x .git/hooks/pre-commit`. Now every `git commit` in `dy-journal` lints
+your vault first.
+
+## Token rotation
+
+Fine-grained PATs expire (90 days max). Rotation:
+
+1. GitHub → Settings → Developer settings → Personal access tokens → Fine-grained → "Regenerate"
+2. Copy new token
+3. Vercel → donovanyohan → Settings → Environment Variables → Update `VAULT_GITHUB_TOKEN`
+4. Trigger a redeploy
+5. (Optional) update local `.env.local`
+6. Calendar reminder for next rotation
+
+If you forget and the token expires, the next deploy will fail with a clear
+401 error message. Production stays on the previous deploy until you rotate.
+
+## Webhook secret rotation (Slice 1+)
+
+For `VAULT_WEBHOOK_SECRET`:
+
+1. Generate new secret: `openssl rand -hex 32`
+2. Vercel: update env var
+3. GitHub → dy-journal → Settings → Webhooks → edit → update secret
+4. In-flight deliveries with old signatures fail with 403 — replay them manually from GitHub's "Recent Deliveries" UI
+
+## Incident response — privacy leak shipped
+
+If a leak somehow makes it past the test (it shouldn't, but):
+
+1. **Immediately:** Vercel dashboard → Deployments → previous good deploy → "Promote to production". The leaked deploy is no longer reachable.
+2. **Rotate** `VAULT_GITHUB_TOKEN` (the leak test gate failed — assume token policy is the only line of defense for the duration of this incident).
+3. **Audit:** GitHub → dy-journal → Settings → Audit log. Vercel → Deployments → check who pulled the leaked URL.
+4. **Post-mortem:** add the leak's specific shape to the leak-test fixture as a new canary. Make sure CI catches it next time. Don't silence the test.
+
+## Versioning + rollback
+
+- Every Vercel deploy is immutable + addressable forever via its
+  `<project>-<deploy-sha>-<team>.vercel.app` URL.
+- Each build stamps `<meta name="vault-sha" content="...">` in HTML and a
+  `vault: N public, M private, K errors (sha: abc1234)` line in build output.
+- Rollback = re-promote a prior deploy in Vercel (no per-note version history
+  in Slice 0).
+
+## Where this contract is enforced
+
+| Guarantee | Where |
+|---|---|
+| Default-deny visibility | `lib/vault/fail-closed.ts` + table tests |
+| Walk ignore-list | `lib/vault/walk.ts` + walk tests |
+| Symlink rejection | `lib/vault/walk.ts` (`followSymbolicLinks: false`) |
+| Tarball traversal | `lib/vault/adapter-github.ts` extraction guards |
+| HTML sanitization | `lib/vault/render.ts` (`rehype-sanitize`) |
+| Wikilink strip | `lib/vault/wikilinks.ts` (remark plugin) |
+| Wikilink-target leak | leak test in CI |
+| No public history | adapter reads working tree only, never `git log` |
+| Module purity | (no enforcement; reviewed via AGENTS.md rules) |
+| Static path mode | `pages/writing/[slug].tsx` `fallback: false` |
+| PAT scope | (manual; documented above) |
+| Build artifact leak | leak test in CI (`test/leak.test.ts`) |
+| HTTP-level leak | leak test in CI (spawns `next start`, curls endpoints) |
+
+If you're modifying any of these, **stop and read `AGENTS.md` first**. Most are
+explicitly load-bearing.

--- a/VAULT.md
+++ b/VAULT.md
@@ -56,9 +56,11 @@ guarantees the privacy boundary makes, and how to debug when notes don't appear.
    (missing field, typo, malformed YAML, `private`, `draft`) → **private**.
 2. **Walk-then-stop-if-private.** Private notes never have their bodies parsed,
    sanitized, or have excerpts computed. Build code only touches public bodies.
-3. **Walk ignore-list.** Files under `.obsidian/`, `.trash/`, `.git/`,
-   `.github/`, `node_modules/`, `templates/` are never read. Even a public note
-   inside `.trash/` stays invisible (move it back to `notes/` to publish).
+3. **Walk ignore-list (the "P17" rule throughout this doc).** Files under
+   `.obsidian/`, `.trash/`, `.git/`, `.github/`, `node_modules/`, `templates/`
+   are never read. Even a public note inside `.trash/` stays invisible (move
+   it back to `notes/` to publish). When this doc references "P17" elsewhere,
+   it means the walk-ignore-list rule defined here.
 4. **Symlinks rejected by default.** No `vault/public.md → /etc/passwd`
    exfiltration vectors.
 5. **Tarball traversal protection.** GitHub Tarball entries with `..`, absolute
@@ -202,7 +204,7 @@ npm run dev
 # 1. Write a note in Obsidian
 # 2. Save (cmd+s)
 # 3. Commit + push from dy-journal:
-cd ~/Documents/Programs/personal/dy-journal
+cd /path/to/dy-journal
 git add . && git commit -m "post: hello world" && git push
 
 # 4. Trigger a Vercel deploy manually (Slice 0 has no webhook yet):
@@ -264,7 +266,7 @@ In `dy-journal/.git/hooks/pre-commit`:
 
 ```bash
 #!/bin/sh
-PORTFOLIO_PATH=/Users/donovanyohan/Documents/Programs/personal/donovanyohan
+PORTFOLIO_PATH=/path/to/donovanyohan
 VAULT_PATH="$(git rev-parse --show-toplevel)"
 cd "$PORTFOLIO_PATH" && npm run vault-lint -- "$VAULT_PATH"
 ```


### PR DESCRIPTION
## Summary

- `lib/vault/walk.ts` — `fast-glob` walk with P17 ignore-list (`.obsidian`, `.trash`, `.git`, `.github`, `node_modules`, `templates`), `followSymbolicLinks: false`, per-file `lstat` symlink rejection, and realpath boundary check
- `lib/vault/wikilinks.ts` — strips all 7 Obsidian wikilink forms (`[[note]]`, `[[note|alias]]`, `[[note#h]]`, `[[note^id]]`, `[[note#h|alias]]`, `[[note^id|alias]]`, `![[embed]]`); remark plugin skips code fences/inline code; `stripWikilinks()` exported for lint/tests
- `lib/vault/adapter-local.ts` — P22 walk-then-stop-if-private pipeline; 1MB size cap; per-file gray-matter parse with try/catch; public-but-malformed throws `VaultParseError`; private-but-malformed silently skipped; per-file isolation (one bad file never kills the whole adapter)
- `lib/vault/adapter-github.ts` — single `fetch` to GitHub Tarball API; `tar.Parser` in-memory parse (no disk write); rejects absolute paths, `../` traversal, symlinks, hardlinks; applies same ignore-list as walk; token redacted in all error messages
- `lib/vault/index.ts` — selects adapter via `VAULT_SOURCE` env; memoized single-flight `getPublicNotes()`; `getNoteBySlug()`; `__resetVaultCache__()` in test env; `getVaultConfig()` throws `VaultConfigError` in production when env vars missing
- `lib/vault/duplicate-check.ts` — N-way collision detection throws `DuplicateSlugError` with all colliding paths and resolutions
- `lib/vault/errors.ts` — `DuplicateSlugError`, `VaultConfigError`, `VaultParseError` per `API_CONTRACT.md`
- `lib/vault/schema.ts` — extended with `VaultNote`, `VaultAdapter`, `VaultConfig`, `AdapterFileResult` types
- `eslint.config.mjs` — `import/no-restricted-paths` rule blocks `pages/**` from importing `adapter-local` or `adapter-github` directly
- `__fixtures__/vault/` — 7 notes (3 public, 2 private, 1 malformed YAML, 1 canary), plus `.obsidian/workspace.json`, `.trash/old-public.md`, `templates/daily-template.md`, and a symlink to `/etc/passwd` for security tests
- `__fixtures__/dy-journal-snapshot/` — deterministic CI snapshot of the real `dy-journal` vault (1 public, 2 private notes)

## Test plan

- [ ] `npm run typecheck` — passes (0 errors)
- [ ] `npm run test:run` — 156 tests pass across 12 test files
- [ ] `./node_modules/.bin/eslint lib/vault/ test/vault/` — 0 errors, 0 warnings
- [ ] No `eslint-disable` in `lib/vault/**`
- [ ] Walk tests: `.obsidian/`, `.trash/`, `templates/` never yielded; symlink to `/etc/passwd` rejected
- [ ] Wikilink tests: all 7 forms stripped; code fences preserved via remark plugin
- [ ] Local adapter: exactly 3 public notes returned; canary never leaks; private bodies never exposed
- [ ] GitHub adapter: path traversal rejected; symlinks rejected; token redacted; ignore-list applied
- [ ] Duplicate check: 3-way collision throws with all 3 paths
- [ ] Index: memoization verified via spy (adapter called only once); `getNoteBySlug` returns null for unknown slugs
- [ ] Integration: `dy-journal-snapshot` returns ≥1 public note without throwing

Stacks on #42 (feat/vault-schema).

Refs #30 #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)