### PR TITLE
feat(vault): extend schema for work-type notes + migrate manulife

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -35,12 +35,40 @@ export interface PreviewConfig {
   image?: string;           // path/URL when kind === 'image'
 }
 
+export type NoteType = 'note' | 'work';
+
+export interface BannerConfig {
+  light?: string;           // public asset path (e.g. '/img/photos/manulifebanner.png')
+  dark?: string;
+}
+
+export interface BgColorConfig {
+  light?: string;           // hex colour (e.g. '#05AC5B')
+  dark?: string;
+}
+
+export interface WorkInfoItem {
+  label: string;            // displayed text
+  href?: string;            // when present, renders as a link
+}
+
 export interface VaultFrontmatter {
   title: string;
   date: string;             // YYYY-MM-DD (Date object coerced to ISO; see P24)
   slug?: string;            // optional override; otherwise derived from filename
   visibility: Visibility;
   preview?: Partial<PreviewConfig>;
+
+  // Work-type fields (Phase A / feat/vault-work-schema)
+  // All optional and backwards-compatible — omitting them leaves existing notes
+  // unaffected. Only meaningful when type === 'work'.
+  type?: NoteType;          // default 'note'
+  subtitle?: string;        // hero description (equivalent to <ArticleHero content>)
+  banner?: BannerConfig;    // hero banner image paths
+  bgColor?: BgColorConfig;  // hero background colour
+  info?: WorkInfoItem[];    // metadata chips in the hero
+  render?: Record<string, string>; // renderer hint map; e.g. { h2: 'highlighter' }
+
   // Passthrough: extra frontmatter keys (e.g. `mood`, `weather`) are preserved
   // but ignored by the publishing pipeline.
   [extra: string]: unknown;

--- a/VAULT.md
+++ b/VAULT.md
@@ -122,6 +122,26 @@ preview:                     # OPTIONAL, all sub-fields optional
   excerpt: First-paragraph override
   image: /img/hero.png       # when kind: image
 mood: focused                # arbitrary passthrough — preserved but ignored
+
+# Work-type fields (Phase A) — only meaningful when type: work
+type: work                   # OPTIONAL; 'note' (default) | 'work'
+subtitle: |                  # OPTIONAL; hero description text
+  Extended description shown below the title in the work-page hero.
+banner:                      # OPTIONAL; hero banner image paths
+  light: /img/photos/hero.png
+  dark: /img/photos/hero-dark.png
+bgColor:                     # OPTIONAL; hero background colour
+  light: "#05AC5B"
+  dark: "#038a49"
+info:                        # OPTIONAL; metadata chips in the hero
+  - label: UI/UX Designer
+  - label: Co-op
+  - label: September - May 2020
+  - label: View on App Store
+    href: https://apps.apple.com/ca/app/manulife-mobile/id1214009312
+render:                      # OPTIONAL; renderer hint map (Phase B NoteRenderer)
+  h2: highlighter            # maps element selector → named preset
+  blockquote: pull-quote
 ---
 
 Body markdown here.

--- a/lib/vault/index.ts
+++ b/lib/vault/index.ts
@@ -24,6 +24,14 @@ import { GitHubVaultAdapter } from "./adapter-github";
 import { assertNoDuplicateSlugs } from "./duplicate-check";
 import { VaultConfigError } from "./errors";
 
+// Re-export new work-type types so consumers can import from lib/vault.
+export type {
+  NoteType,
+  BannerConfig,
+  BgColorConfig,
+  WorkInfoItem,
+} from "./schema";
+
 // ── Config ────────────────────────────────────────────────────────────────────
 
 /**

--- a/lib/vault/schema.ts
+++ b/lib/vault/schema.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 
 export type Visibility = "public" | "private";
 export type PreviewKind = "text" | "image" | "quote" | "embed";
+export type NoteType = "note" | "work";
 
 // ── Sub-schemas ───────────────────────────────────────────────────────────────
 
@@ -47,6 +48,39 @@ export interface PreviewConfig {
   image?: string;
 }
 
+/**
+ * BannerConfig: light/dark image paths for the work-page hero banner.
+ * Only meaningful when `type: work`.
+ */
+export const BannerConfigSchema = z.object({
+  light: z.string().optional(),
+  dark: z.string().optional(),
+});
+
+export type BannerConfig = z.infer<typeof BannerConfigSchema>;
+
+/**
+ * BgColorConfig: light/dark hex colour for the work-page hero background.
+ * Only meaningful when `type: work`.
+ */
+export const BgColorConfigSchema = z.object({
+  light: z.string().optional(),
+  dark: z.string().optional(),
+});
+
+export type BgColorConfig = z.infer<typeof BgColorConfigSchema>;
+
+/**
+ * WorkInfoItem: a single metadata chip displayed in the work-page hero.
+ * `href` is optional — when present the chip renders as a link.
+ */
+export const WorkInfoItemSchema = z.object({
+  label: z.string(),
+  href: z.string().optional(),
+});
+
+export type WorkInfoItem = z.infer<typeof WorkInfoItemSchema>;
+
 // ── Main frontmatter schema ───────────────────────────────────────────────────
 
 /**
@@ -59,6 +93,10 @@ export interface PreviewConfig {
  *   - JS `Date` (from YAML auto-parse) → ISO `YYYY-MM-DD` string
  *   - Strings → passed through as-is for regex validation
  *   - Anything else → passed through (will fail regex, so resolves to private)
+ *
+ * Work-type fields (`type`, `subtitle`, `banner`, `bgColor`, `info`, `render`)
+ *   are all optional and backwards-compatible. Existing note fixtures that omit
+ *   them continue to validate unchanged.
  */
 export const VaultFrontmatterSchema = z
   .object({
@@ -90,6 +128,50 @@ export const VaultFrontmatterSchema = z
     visibility: z.enum(["public", "private"]).default("private"),
 
     preview: PreviewConfigSchema.optional(),
+
+    // ── Work-type fields (Layer B, Phase A) ────────────────────────────────
+    // All optional. Backwards-compatible: existing notes that omit them are
+    // unaffected. Only meaningful when `type: work`; ignored by the note
+    // renderer for `type: note` (default).
+
+    /**
+     * `type` — content category. Defaults to `"note"` for all existing notes.
+     * `"work"` enables work-page-specific rendering in Phase B (NoteRenderer).
+     */
+    type: z.enum(["note", "work"]).default("note").optional(),
+
+    /**
+     * `subtitle` — extended description shown in the work-page hero below the
+     * title. Equivalent to the `content` prop on `<ArticleHero>`.
+     */
+    subtitle: z.string().optional(),
+
+    /**
+     * `banner` — hero banner image paths. `light` and `dark` each accept a
+     * public asset path (e.g. `/img/photos/manulifebanner.png`).
+     */
+    banner: BannerConfigSchema.optional(),
+
+    /**
+     * `bgColor` — hero background colour. Accepts hex strings
+     * (e.g. `"#05AC5B"`). Phase B maps these to CSS custom properties.
+     */
+    bgColor: BgColorConfigSchema.optional(),
+
+    /**
+     * `info` — ordered list of metadata chips for the work-page hero.
+     * Items without `href` render as plain text; items with `href` render
+     * as links. Equivalent to the `info` prop on `<ArticleHero>`.
+     */
+    info: z.array(WorkInfoItemSchema).optional(),
+
+    /**
+     * `render` — renderer hint map (Layer B per spec).
+     * Maps element selectors to named render presets so Phase B's NoteRenderer
+     * can apply visual treatments without baking them into markdown.
+     * Example: `{ h2: "highlighter", blockquote: "pull-quote" }`.
+     */
+    render: z.record(z.string(), z.string()).optional(),
   })
   .passthrough();
 

--- a/lib/vault/schema.ts
+++ b/lib/vault/schema.ts
@@ -53,8 +53,16 @@ export interface PreviewConfig {
  * Only meaningful when `type: work`.
  */
 export const BannerConfigSchema = z.object({
-  light: z.string().optional(),
-  dark: z.string().optional(),
+  // Public-asset paths must start with `/` so the renderer can serve them
+  // directly without relative-path ambiguity. Leak-test friendly.
+  light: z
+    .string()
+    .startsWith("/", "banner.light must be a public asset path starting with /")
+    .optional(),
+  dark: z
+    .string()
+    .startsWith("/", "banner.dark must be a public asset path starting with /")
+    .optional(),
 });
 
 export type BannerConfig = z.infer<typeof BannerConfigSchema>;
@@ -63,9 +71,19 @@ export type BannerConfig = z.infer<typeof BannerConfigSchema>;
  * BgColorConfig: light/dark hex colour for the work-page hero background.
  * Only meaningful when `type: work`.
  */
+// Hex colour validator — accepts #RGB or #RRGGBB. Rejects malformed colours
+// that would silently break the hero rendering in Phase B.
+const HEX_COLOR = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
+
 export const BgColorConfigSchema = z.object({
-  light: z.string().optional(),
-  dark: z.string().optional(),
+  light: z
+    .string()
+    .regex(HEX_COLOR, "bgColor.light must be a hex colour (#RGB or #RRGGBB)")
+    .optional(),
+  dark: z
+    .string()
+    .regex(HEX_COLOR, "bgColor.dark must be a hex colour (#RGB or #RRGGBB)")
+    .optional(),
 });
 
 export type BgColorConfig = z.infer<typeof BgColorConfigSchema>;
@@ -75,7 +93,8 @@ export type BgColorConfig = z.infer<typeof BgColorConfigSchema>;
  * `href` is optional — when present the chip renders as a link.
  */
 export const WorkInfoItemSchema = z.object({
-  label: z.string(),
+  // Non-empty label so an info chip is never blank in the hero.
+  label: z.string().min(1, "info[].label cannot be empty"),
   href: z.string().optional(),
 });
 
@@ -138,7 +157,11 @@ export const VaultFrontmatterSchema = z
      * `type` — content category. Defaults to `"note"` for all existing notes.
      * `"work"` enables work-page-specific rendering in Phase B (NoteRenderer).
      */
-    type: z.enum(["note", "work"]).default("note").optional(),
+    // `.default()` already makes the field optional at the input layer; do NOT
+    // add `.optional()` after, which would cause Zod to infer `T | undefined`
+    // and effectively bypass the default when the key is missing. The
+    // discriminator must always resolve to "note" or "work" at runtime.
+    type: z.enum(["note", "work"]).default("note"),
 
     /**
      * `subtitle` — extended description shown in the work-page hero below the

--- a/test/vault/duplicate-check.test.ts
+++ b/test/vault/duplicate-check.test.ts
@@ -15,6 +15,7 @@ function makeNote(slug: string, filepath: string, frontmatterSlug?: string): Vau
       title: "Test Note",
       date: "2026-05-10",
       visibility: "public",
+      type: "note",
       ...(frontmatterSlug ? { slug: frontmatterSlug } : {}),
     },
     body: "<p>body</p>",


### PR DESCRIPTION
## Summary

- Extends `VaultFrontmatterSchema` with six optional, backwards-compatible work-type frontmatter fields: `type`, `subtitle`, `banner`, `bgColor`, `info`, and `render`
- Adds new sub-schemas (`BannerConfigSchema`, `BgColorConfigSchema`, `WorkInfoItemSchema`) and re-exports their types from `lib/vault/index.ts`
- Updates `API_CONTRACT.md` and `VAULT.md` frontmatter contract sections to document the new fields
- Migrates `pages/work/manulife.tsx` to `notes/work/manulife.md` in dy-journal (slug: `work-manulife`)

## New frontmatter fields

All fields are optional. Existing notes that omit them validate unchanged.

| Field | Type | Notes |
|---|---|---|
| `type` | `"note" \| "work"` | Defaults to `"note"`. Enables work-page rendering in Phase B. |
| `subtitle` | `string` | Hero description (equivalent to `<ArticleHero content>`). |
| `banner.light` / `.dark` | `string` | Public asset paths for the hero banner image. |
| `bgColor.light` / `.dark` | `string` | Hex colour for the hero background. |
| `info` | `{ label, href? }[]` | Metadata chips in the hero. `href` makes a chip a link. |
| `render` | `Record<string, string>` | Renderer hint map. Phase B NoteRenderer consumes this. E.g. `{ h2: "highlighter" }`. |

## Test results

All 221 existing tests pass. TypeScript typecheck passes with no errors.

```
Test Files  15 passed (15)
     Tests  221 passed (221)
```

## dy-journal commit

https://github.com/donovan-yohan/dy-journal/commit/5e1404d

`notes/work/manulife.md` (slug: `work-manulife`) is now public in the vault. Image refs point at the existing `/img/photos/work/*` public assets in this repo. Vault asset pipeline lands in a later PR.

## What this PR does NOT include

- NoteRenderer changes — `pages/writing/[slug].tsx` is unchanged. The work-type fields are stored in frontmatter and available in `note.frontmatter`; Phase B will use them.
- Migration of the remaining 6 work pages — Phase C.
- Any changes to `pages/work/*.tsx` — the existing TSX routes continue to work as before.

## Phase context

- **Phase A (this PR):** Schema extension + manulife migration
- **Phase B (next):** NoteRenderer consumes `render` hint map and work-type fields to apply visual treatments
- **Phase C:** Migrate remaining 6 work pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "work"-type notes support with optional frontmatter fields: subtitle, banner configuration, background color, metadata info items with optional links, and renderer hint mappings. All changes are fully backwards-compatible.

* **Documentation**
  * Updated vault API contract and documentation with specifications and examples for new work-note frontmatter fields and rendering options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/donovanyohan/pull/51)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->