### PR TITLE
Fix about timeline scale and narrow horizontal mode

### DIFF
--- a/components/about/HeroComposition.tsx
+++ b/components/about/HeroComposition.tsx
@@ -38,10 +38,10 @@ const WALK_FRAMES: readonly string[] = [
  * Keep length in sync with WALK_FRAMES.
  */
 const FRAME_POSITIONS: readonly number[] = [
-  0,    // walk_1 — turning, in place
-  0,    // walk_2 — turning, in place
-  0,    // walk_3 — turning, now facing right
-  0.2,  // walk_4 — first step
+  0, // walk_1 — turning, in place
+  0, // walk_2 — turning, in place
+  0, // walk_3 — turning, now facing right
+  0.2, // walk_4 — first step
   0.45, // walk_5 — mid stride
   0.75, // walk_6 — walked out of the frame
 ];
@@ -81,12 +81,8 @@ const walkOffsetForProgress = (p: number): number => {
   const hi = Math.min(lo + 1, N - 1);
   const segLocal = framePos - lo;
   const blend = lo === hi ? 0 : bandBlend(segLocal, TRANSITION_BAND);
-  return (
-    FRAME_POSITIONS[lo] +
-    (FRAME_POSITIONS[hi] - FRAME_POSITIONS[lo]) * blend
-  );
+  return FRAME_POSITIONS[lo] + (FRAME_POSITIONS[hi] - FRAME_POSITIONS[lo]) * blend;
 };
-
 
 interface HeroCompositionProps {
   monoClass: string;
@@ -172,11 +168,7 @@ export const HeroComposition = ({
   });
 
   return (
-    <section
-      ref={heroRef}
-      className="heroComp"
-      aria-labelledby="aboutHeroTitle"
-    >
+    <section ref={heroRef} className="heroComp" aria-labelledby="aboutHeroTitle">
       <div className="heroCompInner">
         {/* LEFT — editorial type stack. */}
         <div className="heroType">
@@ -186,11 +178,7 @@ export const HeroComposition = ({
             ABOUT · INDEX · DONOVAN YOHAN
           </motion.span>
 
-          <motion.h1
-            id="aboutHeroTitle"
-            className={`heroTitle ${monoBoldClass}`}
-            {...fade(0.18)}
-          >
+          <motion.h1 id="aboutHeroTitle" className={`heroTitle ${monoBoldClass}`} {...fade(0.18)}>
             <span className="heroTitleRow heroTitleKicker">
               ISSUE 021 &nbsp;/&nbsp; SIDE-QUEST GAZETTE
             </span>
@@ -199,7 +187,9 @@ export const HeroComposition = ({
             </span>
             <span className="heroTitleRow heroTitleMega">
               <span className="heroTitleMark heroTitleMarkBlue">YOHAN</span>
-              <span className="heroTitleSlash" aria-hidden>/</span>
+              <span className="heroTitleSlash" aria-hidden>
+                /
+              </span>
             </span>
             <span className="heroTitleRow heroTitleDeck">
               THE LONG VERSION, SCROLLED SIDEWAYS &mdash; <br />
@@ -207,14 +197,10 @@ export const HeroComposition = ({
             </span>
           </motion.h1>
 
-          <motion.p
-            className={`heroLead ${serifClass}`}
-            {...fade(0.35)}
-          >
-            Senior front-end engineer. Hobby-collector.
-            What follows is{" "}
-            <em className={italicSerifClass}>the long version</em> &mdash; one
-            card per beat, newest first.
+          <motion.p className={`heroLead ${serifClass}`} {...fade(0.35)}>
+            Senior front-end engineer. Hobby-collector. What follows is{" "}
+            <em className={italicSerifClass}>the long version</em> &mdash; one card per beat, newest
+            first.
           </motion.p>
 
           <motion.div className="heroCta" {...fade(0.5, 18)}>
@@ -236,7 +222,8 @@ export const HeroComposition = ({
               </span>
             </span>
             <span className={`heroCtaHint ${monoClass}`}>
-              wheel down · or drag
+              <span className="heroCtaHintDesktop">wheel down · or drag</span>
+              <span className="heroCtaHintTouch">swipe / drag sideways</span>
             </span>
           </motion.div>
 
@@ -285,8 +272,7 @@ export const HeroComposition = ({
               className="figureImgWrap"
               style={
                 {
-                  ["--walk-offset" as string]:
-                    walkOffsetForProgress(flipProgress),
+                  ["--walk-offset" as string]: walkOffsetForProgress(flipProgress),
                 } as React.CSSProperties
               }
             >
@@ -300,17 +286,14 @@ export const HeroComposition = ({
 
             {/* Web-UI sticker chips on the frame. */}
             <span className={`frameChipTopLeft ${monoBoldClass}`}>
-              <span className="chipArrow" aria-hidden>&lsaquo;</span> 021
+              <span className="chipArrow" aria-hidden>
+                &lsaquo;
+              </span>{" "}
+              021
             </span>
             <span className={`frameChipTopRight ${monoBoldClass}`}>
               <span className="chipDot" aria-hidden />
               ABOUT
-            </span>
-            <span className={`frameChipBottomLeft ${monoClass}`}>
-              FUTURE-FACING · NOW &rarr; 2006
-            </span>
-            <span className={`frameChipBottomRight ${monoBoldClass}`}>
-              S-{new Date().getFullYear()}x
             </span>
           </motion.div>
 
@@ -368,7 +351,7 @@ export const HeroComposition = ({
       <style jsx>{`
         .heroComp {
           flex: 0 0 auto;
-          width: calc(100vw - 128px);
+          width: var(--hero-panel-w);
           height: 100%;
           background: var(--paper);
           border-right: 1px solid var(--rule);
@@ -391,8 +374,7 @@ export const HeroComposition = ({
           position: relative;
           width: 100%;
           height: 100%;
-          padding: calc(2 * var(--u)) calc(3 * var(--u)) calc(2 * var(--u))
-            var(--content-pad-left);
+          padding: calc(2 * var(--u)) calc(3 * var(--u)) calc(2 * var(--u)) var(--content-pad-left);
         }
 
         /* ---- LEFT type stack -------------------------------------------- */
@@ -480,11 +462,7 @@ export const HeroComposition = ({
           padding: 0 0.04em;
           margin: 0 -0.04em;
           color: var(--ink);
-          background-image: linear-gradient(
-            to right,
-            var(--hl),
-            var(--hl)
-          );
+          background-image: linear-gradient(to right, var(--hl), var(--hl));
           background-position: 0 88%;
           background-size: 100% 0.18em;
           background-repeat: no-repeat;
@@ -521,7 +499,8 @@ export const HeroComposition = ({
           color: var(--paper);
           font-size: 13px;
           letter-spacing: 0.24em;
-          border-radius: 999px;
+          border: 1px solid var(--ink);
+          border-radius: 0;
         }
         [data-theme="dark"] .heroCtaPill {
           background: var(--paper);
@@ -537,6 +516,9 @@ export const HeroComposition = ({
           text-transform: uppercase;
           color: var(--ink-mute);
         }
+        .heroCtaHintTouch {
+          display: none;
+        }
 
         /* Dot matrix anchor, lower-left chrome echoing the reference UI. */
         .heroDots {
@@ -545,10 +527,7 @@ export const HeroComposition = ({
           bottom: -8px;
           width: 96px;
           height: 64px;
-          background-image: radial-gradient(
-            var(--ink-mute) 1.6px,
-            transparent 1.8px
-          );
+          background-image: radial-gradient(var(--ink-mute) 1.6px, transparent 1.8px);
           background-size: 12px 12px;
           background-position: 0 0;
           opacity: 0.65;
@@ -702,11 +681,7 @@ export const HeroComposition = ({
              0..1 fraction of the hero panel's width, computed from
              a per-frame position table — see FRAME_POSITIONS). */
           will-change: transform;
-          transform: translate3d(
-            calc((100vw - 128px) * var(--walk-offset, 0)),
-            0,
-            0
-          );
+          transform: translate3d(calc(var(--hero-panel-w) * var(--walk-offset, 0)), 0, 0);
         }
         :global(.figureImg) {
           z-index: 2;
@@ -801,17 +776,109 @@ export const HeroComposition = ({
           font-size: 11px;
           letter-spacing: 0.3em;
           color: var(--ink-mute);
+          opacity: 0.55;
           z-index: 4;
         }
 
-        @media (max-width: 900px) {
+        @media (max-width: 600px) {
           .heroCompInner {
-            grid-template-columns: 1fr;
-            padding: calc(2 * var(--u));
-            gap: calc(2 * var(--u));
+            padding: calc(2 * var(--u)) var(--u) var(--u);
+          }
+          .heroType {
+            justify-content: flex-start;
+            gap: calc(0.9 * var(--u));
+            max-width: 100%;
+            padding-top: calc(1.25 * var(--u));
+          }
+          .heroIndex {
+            gap: 8px;
+            font-size: 9px;
+            letter-spacing: 0.16em;
+          }
+          .heroIndexDivider {
+            width: 18px;
+          }
+          .heroTitleKicker {
+            font-size: 9px;
+            letter-spacing: 0.18em;
+            line-height: 1.35;
+            margin-bottom: 4px;
+          }
+          .heroTitleMega {
+            font-size: clamp(50px, 15.5vw, 62px);
+            line-height: 0.88;
+            letter-spacing: -0.055em;
+          }
+          .heroTitleDeck {
+            font-size: 10px;
+            letter-spacing: 0.14em;
+            line-height: 1.45;
+            max-width: 29ch;
+          }
+          .heroLead {
+            font-size: 16px;
+            line-height: 1.45;
+            max-width: 30ch;
+          }
+          .heroCta {
+            align-items: flex-start;
+            flex-direction: column;
+            gap: 8px;
+            margin-top: 2px;
+          }
+          .heroCtaPill {
+            padding: 7px 10px 7px 14px;
+            font-size: 11px;
+            letter-spacing: 0.18em;
+          }
+          .heroCtaPillArrow {
+            width: 30px;
+            height: 16px;
+          }
+          .heroCtaHintDesktop {
+            display: none;
+          }
+          .heroCtaHintTouch {
+            display: inline;
+          }
+          .heroDots,
+          .bgStripesRed,
+          .bgLinesBlue,
+          .accentAsterisk,
+          .accentSparkle,
+          .heroEdge {
+            display: none;
           }
           .heroStage {
-            min-height: 420px;
+            inset: auto -18px 34px auto;
+            width: 170px;
+            height: 315px;
+            align-items: center;
+            justify-content: center;
+            opacity: 0.42;
+          }
+          .figureFrame {
+            height: 300px;
+            border-width: 2px;
+            padding: 7px;
+          }
+          .figureFrame::before,
+          .figureFrame::after {
+            width: 10px;
+            height: 10px;
+          }
+          .frameChipTopLeft,
+          .frameChipTopRight {
+            font-size: 9px;
+            letter-spacing: 0.14em;
+          }
+          .accentStar {
+            right: 10px;
+            top: auto;
+            bottom: 260px;
+            width: 34px;
+            height: 34px;
+            opacity: 0.7;
           }
         }
       `}</style>

--- a/components/about/TimelineCard.tsx
+++ b/components/about/TimelineCard.tsx
@@ -171,14 +171,9 @@ export const TimelineCard = ({
     ? accent.markColor[theme === "dark" ? "dark" : "light"]
     : undefined;
 
-  const { lead, mark, tail } = useMemo(
-    () => splitTitleForMark(event.title),
-    [event.title],
-  );
+  const { lead, mark, tail } = useMemo(() => splitTitleForMark(event.title), [event.title]);
 
-  const dateline = event.stamp
-    ? `${event.stamp} · ${event.year}`
-    : `${event.year}`;
+  const dateline = event.stamp ? `${event.stamp} · ${event.year}` : `${event.year}`;
 
   const frameStyle: CSSProperties = {
     borderColor: accent.band,
@@ -202,9 +197,7 @@ export const TimelineCard = ({
         {/* Top accent band — date stamp reversed out of it. */}
         <motion.div className="tCardBand" style={bandStyle} variants={slideVariants}>
           <span className={`tCardBandText ${monoBoldClass}`}>{dateline}</span>
-          <span className={`tCardBandIndex ${monoClass}`}>
-            {String(seed).padStart(2, "0")}
-          </span>
+          <span className={`tCardBandIndex ${monoClass}`}>{String(seed).padStart(2, "0")}</span>
         </motion.div>
 
         {/* Media — clean frame, offset geometric shape behind. */}
@@ -285,32 +278,29 @@ export const TimelineCard = ({
         ) : null}
       </div>
 
-      <style jsx>{`
+      <style jsx global>{`
         .tCard {
-          flex: 0 0 auto;
-          width: calc(28 * var(--u));
+          flex: 0 0 var(--timeline-card-w);
+          width: var(--timeline-card-w);
           height: 100%;
           display: flex;
           align-items: center;
+          min-width: 0;
         }
         .tCardFrame {
           position: relative;
           width: 100%;
-          max-height: 100%;
+          height: min(640px, calc(100% - 24px));
           border: 1.5px solid;
           background: var(--paper-2);
-          box-shadow:
-            6px 6px 0 0 var(--ink),
-            0 0 0 1px var(--ink) inset;
+          box-shadow: 3px 3px 0 0 var(--ink);
           display: flex;
           flex-direction: column;
           min-height: 0;
           overflow: hidden;
         }
-        :global([data-theme="dark"]) .tCardFrame {
-          box-shadow:
-            6px 6px 0 0 rgba(250, 247, 236, 0.12),
-            0 0 0 1px rgba(250, 247, 236, 0.18) inset;
+        [data-theme="dark"] .tCardFrame {
+          box-shadow: 3px 3px 0 0 rgba(250, 247, 236, 0.14);
         }
         .tCardBand {
           flex: 0 0 auto;
@@ -335,7 +325,7 @@ export const TimelineCard = ({
           position: relative;
           width: 100%;
           aspect-ratio: 4 / 3;
-          max-height: 55%;
+          max-height: 48%;
           flex: 0 0 auto;
           padding: calc(0.75 * var(--u));
           display: flex;
@@ -360,7 +350,7 @@ export const TimelineCard = ({
           align-items: center;
           justify-content: center;
         }
-        :global(.tCardImg) {
+        .tCardImg {
           width: 100%;
           height: 100%;
           object-fit: cover;
@@ -384,8 +374,8 @@ export const TimelineCard = ({
         }
         .tCardTitle {
           margin: 0;
-          font-size: 22px;
-          line-height: 1.12;
+          font-size: 24px;
+          line-height: 1.16;
           font-weight: 400;
           color: var(--ink);
           flex: 0 0 auto;
@@ -393,12 +383,12 @@ export const TimelineCard = ({
         .tCardCopy {
           margin: 0;
           font-size: 14px;
-          line-height: 1.45;
+          line-height: 1.5;
           color: var(--ink-soft);
           flex: 1 1 auto;
           overflow: hidden;
           display: -webkit-box;
-          -webkit-line-clamp: 6;
+          -webkit-line-clamp: 5;
           -webkit-box-orient: vertical;
         }
         .tCardDeco {
@@ -409,6 +399,45 @@ export const TimelineCard = ({
           height: 56px;
           pointer-events: none;
           z-index: 2;
+        }
+
+        @media (max-width: 600px) {
+          .tCardFrame {
+            height: min(580px, calc(100% - 32px));
+            box-shadow: 2px 2px 0 0 var(--ink);
+          }
+          [data-theme="dark"] .tCardFrame {
+            box-shadow: 2px 2px 0 0 rgba(250, 247, 236, 0.14);
+          }
+          .tCardBand {
+            padding: 5px 10px;
+          }
+          .tCardBandText {
+            font-size: 10px;
+            letter-spacing: 0.18em;
+          }
+          .tCardMediaWrap {
+            padding: 10px;
+            max-height: 44%;
+          }
+          .tCardBody {
+            padding: 8px 12px 12px;
+          }
+          .tCardTitle {
+            font-size: 21px;
+            line-height: 1.16;
+          }
+          .tCardCopy {
+            font-size: 14px;
+            line-height: 1.46;
+            -webkit-line-clamp: 5;
+          }
+          .tCardDeco {
+            width: 42px;
+            height: 42px;
+            right: -8px;
+            bottom: -8px;
+          }
         }
       `}</style>
     </motion.article>

--- a/components/about/TimelineRail.tsx
+++ b/components/about/TimelineRail.tsx
@@ -17,37 +17,21 @@ import { HiSpan } from "../Highlighter";
 
 interface TimelineRailProps {
   events: TimelineEvent[];
-  /** Stride from one card's left edge to the next, in px (card + gap). */
-  cardStrideX: number;
-  /** Width of a single card, in px. Used to center ticks over their card. */
-  cardWidthX: number;
-  /** Left padding before the first card, in px. */
-  leftPadX: number;
-  /** Right padding after the last card, in px. Used to size the rail. */
-  rightPadX: number;
   monoClass: string;
   monoBoldClass: string;
 }
 
 interface YearTick {
   year: number;
-  /** Center x of all events tagged with this year, in px from rail origin. */
-  centerX: number;
+  /** Center x of all events tagged with this year, as a CSS length. */
+  centerX: string;
   /** Whether to render the big highlighted label. */
   emphasize: boolean;
   /** Stamp (NOW / START) if any of the events for this year has one. */
   stamp?: string;
 }
 
-export const TimelineRail = ({
-  events,
-  cardStrideX,
-  cardWidthX,
-  leftPadX,
-  rightPadX,
-  monoClass,
-  monoBoldClass,
-}: TimelineRailProps) => {
+export const TimelineRail = ({ events, monoClass, monoBoldClass }: TimelineRailProps) => {
   const ticks = useMemo<YearTick[]>(() => {
     const byYear = new Map<number, { indices: number[]; stamp?: string }>();
     events.forEach((e, i) => {
@@ -61,9 +45,8 @@ export const TimelineRail = ({
     sortedYears.forEach((year, idx) => {
       const bucket = byYear.get(year);
       if (!bucket) return;
-      const avgIndex =
-        bucket.indices.reduce((s, n) => s + n, 0) / bucket.indices.length;
-      const centerX = leftPadX + avgIndex * cardStrideX + cardWidthX / 2;
+      const avgIndex = bucket.indices.reduce((s, n) => s + n, 0) / bucket.indices.length;
+      const centerX = `calc(var(--timeline-left-pad) + ${avgIndex} * (var(--timeline-card-w) + var(--timeline-gap)) + var(--timeline-card-w) / 2)`;
       result.push({
         year,
         centerX,
@@ -72,15 +55,9 @@ export const TimelineRail = ({
       });
     });
     return result;
-  }, [events, cardStrideX, cardWidthX, leftPadX]);
+  }, [events]);
 
-  const gapX = cardStrideX - cardWidthX;
-  const trackWidth =
-    leftPadX +
-    events.length * cardWidthX +
-    Math.max(0, events.length - 1) * gapX +
-    rightPadX;
-
+  const trackWidth = `calc(var(--timeline-left-pad) + ${events.length} * var(--timeline-card-w) + ${Math.max(0, events.length - 1)} * var(--timeline-gap) + var(--timeline-right-pad))`;
   const trackStyle: CSSProperties = { width: trackWidth };
 
   return (
@@ -89,9 +66,7 @@ export const TimelineRail = ({
         {ticks.map((t) => (
           <div key={t.year} className="railTick" style={{ left: t.centerX }}>
             <span className="railTickMark" />
-            {t.stamp ? (
-              <span className={`railStamp ${monoBoldClass}`}>{t.stamp}</span>
-            ) : null}
+            {t.stamp ? <span className={`railStamp ${monoBoldClass}`}>{t.stamp}</span> : null}
             <span
               className={`railYear ${
                 t.emphasize ? monoBoldClass : monoClass
@@ -114,12 +89,12 @@ export const TimelineRail = ({
           </div>
         ))}
       </div>
-      <div className="railRule" aria-hidden style={{ width: trackWidth }} />
+      <div className="railRule" aria-hidden style={trackStyle} />
 
       <style jsx>{`
         .rail {
           position: relative;
-          height: calc(5 * var(--u));
+          height: var(--rail-lane-h);
           flex: 0 0 auto;
         }
         .railTrack {

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -18,6 +18,7 @@
 import Head from "next/head";
 import dynamic from "next/dynamic";
 import { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
 
 import { timeline } from "../global/timeline";
 import { TimelineCard } from "../components/about/TimelineCard";
@@ -31,14 +32,10 @@ import { dotGridColor } from "../lib/dot-grid-color";
 
 const DotGrid = dynamic(() => import("../components/lab/DotGrid"), { ssr: false });
 
-// Lane geometry, in 16px units. Stride = card + gap, kept in sync with
-// `.aboutLane { gap }` and `.tCard { width }`.
-const CARD_U = 28;
-const GAP_U = 3;
-const STRIDE_U = CARD_U + GAP_U;
+// Desktop lane geometry lives in CSS variables so narrow viewports can keep
+// the same horizontal timeline while shrinking cards to the viewport.
 const LEFT_PAD_U = 2;
 const RIGHT_PAD_U = 8;
-const UPX = 16;
 
 const About = () => {
   const scrollerRef = useRef<HTMLDivElement>(null);
@@ -80,11 +77,36 @@ const About = () => {
           return next;
         });
       },
-      { root: el, rootMargin: "0px -10% 0px -10%", threshold: 0.2 },
+      { root: el, rootMargin: "0px -10% 0px -10%", threshold: 0.2 }
     );
     targets.forEach((t) => io.observe(t));
     return () => io.disconnect();
   }, []);
+
+  const handleShellKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const el = scrollerRef.current;
+    if (!el) return;
+
+    const lane = el.querySelector<HTMLElement>(".aboutLane");
+    const slot = el.querySelector<HTMLElement>(".aboutSlot");
+    const gap = lane ? Number.parseFloat(window.getComputedStyle(lane).columnGap) || 48 : 48;
+    const stride = (slot?.getBoundingClientRect().width || 448) + gap;
+
+    let left: number | null = null;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown" || event.key === "PageDown") {
+      left = el.scrollLeft + stride;
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp" || event.key === "PageUp") {
+      left = el.scrollLeft - stride;
+    } else if (event.key === "Home") {
+      left = 0;
+    } else if (event.key === "End") {
+      left = el.scrollWidth;
+    }
+
+    if (left === null) return;
+    event.preventDefault();
+    el.scrollTo({ left, behavior: "smooth" });
+  };
 
   return (
     <>
@@ -96,7 +118,14 @@ const About = () => {
 
       <SiteNav current="about" />
 
-      <div className="aboutShell" ref={scrollerRef}>
+      <div
+        className="aboutShell"
+        ref={scrollerRef}
+        tabIndex={0}
+        role="region"
+        aria-label="Horizontal about timeline. Use arrow keys, wheel, drag, or swipe to move sideways."
+        onKeyDown={handleShellKeyDown}
+      >
         <DotGrid
           spacing={16}
           maxRadiusBoost={1.1}
@@ -117,21 +146,13 @@ const About = () => {
         <section className="aboutTimeline">
           <TimelineRail
             events={timeline}
-            cardStrideX={STRIDE_U * UPX}
-            cardWidthX={CARD_U * UPX}
-            leftPadX={LEFT_PAD_U * UPX}
-            rightPadX={RIGHT_PAD_U * UPX}
             monoClass={gm500.className}
             monoBoldClass={gm800.className}
           />
           <div className="aboutLane">
             <div className="aboutLanePad" aria-hidden />
             {timeline.map((event, i) => (
-              <div
-                key={event.id}
-                className="aboutSlot"
-                data-tcard-id={event.id}
-              >
+              <div key={event.id} className="aboutSlot" data-tcard-id={event.id}>
                 <TimelineCard
                   event={event}
                   monoClass={gm500.className}
@@ -163,6 +184,12 @@ const About = () => {
           --gutter-w: calc(12 * var(--u));
           --gutter-pad: var(--u);
           --content-pad-left: calc(var(--gutter-w) + var(--gutter-pad));
+          --hero-panel-w: calc(100vw - 128px);
+          --timeline-card-w: calc(28 * var(--u));
+          --timeline-gap: calc(3 * var(--u));
+          --timeline-left-pad: calc(${LEFT_PAD_U} * var(--u));
+          --timeline-right-pad: calc(${RIGHT_PAD_U} * var(--u));
+          --rail-lane-h: calc(5 * var(--u));
           /* Highlighter tab colours — mirrored from the home page so the nav
              reads identically across routes. */
           --hl-1: rgba(120, 220, 255, 0.55);
@@ -191,7 +218,8 @@ const About = () => {
           --hl-4: rgba(230, 130, 50, 0.55);
           --logo-bg: #c8632b;
         }
-        html, body {
+        html,
+        body {
           margin: 0;
           padding: 0;
           height: 100%;
@@ -201,7 +229,22 @@ const About = () => {
           overflow: hidden;
           overscroll-behavior: none;
         }
-        * { box-sizing: border-box; }
+        * {
+          box-sizing: border-box;
+        }
+
+        @media (max-width: 600px) {
+          :root {
+            --gutter-w: calc(2 * var(--u));
+            --content-pad-left: calc(2 * var(--u));
+            --hero-panel-w: calc(100vw - 32px);
+            --timeline-card-w: calc(100vw - 32px);
+            --timeline-gap: var(--u);
+            --timeline-left-pad: var(--u);
+            --timeline-right-pad: calc(2 * var(--u));
+            --rail-lane-h: calc(4 * var(--u));
+          }
+        }
       `}</style>
 
       <style jsx global>{`
@@ -218,8 +261,17 @@ const About = () => {
           overflow-y: hidden;
           scrollbar-width: none;
           overscroll-behavior: none;
+          outline: none;
+          scroll-snap-type: x proximity;
+          -webkit-overflow-scrolling: touch;
         }
-        .aboutShell::-webkit-scrollbar { display: none; }
+        .aboutShell:focus-visible {
+          outline: 2px solid var(--ink);
+          outline-offset: -4px;
+        }
+        .aboutShell::-webkit-scrollbar {
+          display: none;
+        }
 
         .aboutTimeline {
           flex: 0 0 auto;
@@ -233,20 +285,29 @@ const About = () => {
           min-height: 0;
           display: flex;
           align-items: center;
-          gap: calc(3 * var(--u));
+          gap: var(--timeline-gap);
         }
         .aboutLanePad {
-          flex: 0 0 calc(${LEFT_PAD_U} * var(--u));
+          flex: 0 0 var(--timeline-left-pad);
+          margin-right: calc(-1 * var(--timeline-gap));
         }
         .aboutLanePadEnd {
-          flex: 0 0 calc(${RIGHT_PAD_U} * var(--u));
+          flex: 0 0 var(--timeline-right-pad);
+          margin-left: calc(-1 * var(--timeline-gap));
         }
         .aboutSlot {
-          flex: 0 0 auto;
+          flex: 0 0 var(--timeline-card-w);
           display: flex;
           align-items: center;
           gap: calc(0.5 * var(--u));
           height: 100%;
+          scroll-snap-align: center;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .aboutShell {
+            scroll-behavior: auto;
+          }
         }
       `}</style>
     </>


### PR DESCRIPTION
## Summary
- Fix timeline card root sizing so cards render from responsive timeline tokens instead of expanding to billboard width.
- Reserve a dedicated rail lane and align rail/card math through shared CSS variables.
- Simplify hero chrome, convert the CTA to a sharp tab, and add readable mobile horizontal sizing/copy.
- Keep dark mode/reduced-motion behavior and add keyboard focus/arrow navigation on the horizontal scroller.

## Verification
- npm run check
- npm run build
- Browser QA via local Next dev server at /about:
  - 1440x900 light/dark: hero 1312px, controlled 96px first-card peek, card frame 448x640, rail 80px, 0px card overflow below shell.
  - 390x844 light/dark: hero 358px, touch cue says “swipe / drag sideways”, card frame 358x580, rail 64px, 0px card overflow below shell.
  - Horizontal scroller focusable; arrow-key target verified in browser metrics.
  - Screenshots/metrics saved locally in /tmp/about-timeline-evidence.

## Risks / case against
- Desktop first-card peek is intentionally 96px; mobile peek is only 16px so the hero stays readable.
- Console still shows existing Next dev warnings for inline themeBootstrap script and LCP image priority; no failed network requests observed.

Refs #57