### PR TITLE
Add vault article asset pipeline

### DIFF
--- a/lib/vault/adapter-github.ts
+++ b/lib/vault/adapter-github.ts
@@ -38,6 +38,13 @@ import { applyPreviewDefaults } from "./preview-defaults";
 import { stripWikilinks } from "./wikilinks";
 import { renderMarkdown } from "./render";
 import { VaultParseError } from "./errors";
+import {
+  isVaultAssetFile,
+  rewriteMarkdownVaultImageRefs,
+  rewritePreviewVaultImage,
+  writeBufferedVaultAsset,
+  MAX_VAULT_ASSET_BYTES,
+} from "./assets";
 import matter from "gray-matter";
 import path from "node:path";
 
@@ -189,11 +196,7 @@ function resolveTarEntry(relPath: string, content: string): ResolvedFile {
 
   const parseResult = VaultFrontmatterSchema.safeParse(rawFrontmatter);
   if (!parseResult.success) {
-    throw new VaultParseError(
-      relPath,
-      "schema",
-      parseResult.error.issues[0]?.message,
-    );
+    throw new VaultParseError(relPath, "schema", parseResult.error.issues[0]?.message);
   }
 
   const frontmatter = parseResult.data as VaultFrontmatter;
@@ -215,15 +218,29 @@ async function renderPublicNote(
   resolved: Extract<ResolvedFile, { visibility: "public" }>,
   publicSlugs: ReadonlySet<string>,
   privateSlugs: ReadonlySet<string>,
+  assets: ReadonlyMap<string, Buffer>
 ): Promise<VaultNote> {
-  const body = await renderMarkdown(resolved.bodyMarkdown, {
+  const bodyMarkdownForRender = await rewriteMarkdownVaultImageRefs(
+    resolved.bodyMarkdown,
+    resolved.relPath,
+    resolved.slug,
+    (asset) => writeBufferedVaultAsset(resolved.relPath, asset, assets.get(asset.sourceRelPath))
+  );
+
+  const body = await renderMarkdown(bodyMarkdownForRender, {
     publicSlugs,
     privateSlugs,
     sourcePath: resolved.relPath,
   });
 
   const firstParagraph = extractFirstParagraph(resolved.bodyMarkdown);
-  const preview = applyPreviewDefaults(resolved.frontmatter.preview, {
+  const previewInput = await rewritePreviewVaultImage(
+    resolved.frontmatter.preview,
+    resolved.relPath,
+    resolved.slug,
+    (asset) => writeBufferedVaultAsset(resolved.relPath, asset, assets.get(asset.sourceRelPath))
+  );
+  const preview = applyPreviewDefaults(previewInput, {
     title: resolved.frontmatter.title,
     firstParagraph,
   });
@@ -250,12 +267,7 @@ export class GitHubVaultAdapter implements VaultAdapter {
   private readonly ref: string;
   private readonly token: string;
 
-  constructor(params: {
-    owner: string;
-    repo: string;
-    ref?: string;
-    token: string;
-  }) {
+  constructor(params: { owner: string; repo: string; ref?: string; token: string }) {
     this.owner = params.owner;
     this.repo = params.repo;
     this.ref = params.ref ?? "HEAD";
@@ -280,14 +292,12 @@ export class GitHubVaultAdapter implements VaultAdapter {
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        `GitHub tarball fetch failed: ${msg.replaceAll(token, "[REDACTED]")}`,
-      );
+      throw new Error(`GitHub tarball fetch failed: ${msg.replaceAll(token, "[REDACTED]")}`);
     }
 
     if (!response.ok) {
       throw new Error(
-        `GitHub tarball fetch returned HTTP ${response.status} for ${this.owner}/${this.repo}@${this.ref}`,
+        `GitHub tarball fetch returned HTTP ${response.status} for ${this.owner}/${this.repo}@${this.ref}`
       );
     }
 
@@ -296,10 +306,10 @@ export class GitHubVaultAdapter implements VaultAdapter {
 
     // Parse entries in-memory — collect file contents before async processing
     const entries: Array<{ relPath: string; content: string }> = [];
+    const assets = new Map<string, Buffer>();
 
     // Detect gzip from magic bytes (0x1f 0x8b)
-    const isGzip =
-      buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b;
+    const isGzip = buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b;
 
     await new Promise<void>((resolve, reject) => {
       const readable = Readable.from(buffer);
@@ -318,7 +328,10 @@ export class GitHubVaultAdapter implements VaultAdapter {
 
           const relPath = stripTarballPrefix(rawPath);
 
-          if (!relPath.startsWith(CONTENT_PREFIX) || !relPath.endsWith(".md")) {
+          const isMarkdown = relPath.startsWith(CONTENT_PREFIX) && relPath.endsWith(".md");
+          const isAsset = isVaultAssetFile(relPath);
+
+          if (!isMarkdown && !isAsset) {
             entry.resume();
             return;
           }
@@ -333,11 +346,11 @@ export class GitHubVaultAdapter implements VaultAdapter {
 
           entry.on("data", (chunk: Buffer) => {
             totalSize += chunk.length;
-            if (totalSize > MAX_FILE_BYTES) {
+            if (totalSize > (isAsset ? MAX_VAULT_ASSET_BYTES : MAX_FILE_BYTES)) {
               entry.destroy(
                 new Error(
-                  `File too large: ${relPath} (>${MAX_FILE_BYTES} bytes)`,
-                ),
+                  `File too large: ${relPath} (>${isAsset ? MAX_VAULT_ASSET_BYTES : MAX_FILE_BYTES} bytes)`
+                )
               );
               return;
             }
@@ -345,8 +358,13 @@ export class GitHubVaultAdapter implements VaultAdapter {
           });
 
           entry.on("end", () => {
-            const content = Buffer.concat(chunks).toString("utf8");
-            entries.push({ relPath, content });
+            const buffer = Buffer.concat(chunks);
+            if (isAsset) {
+              assets.set(relPath, buffer);
+            } else {
+              const content = buffer.toString("utf8");
+              entries.push({ relPath, content });
+            }
           });
 
           entry.on("error", () => {
@@ -395,10 +413,9 @@ export class GitHubVaultAdapter implements VaultAdapter {
     const publicNotes = await Promise.all(
       resolved
         .filter(
-          (r): r is Extract<ResolvedFile, { visibility: "public" }> =>
-            r.visibility === "public",
+          (r): r is Extract<ResolvedFile, { visibility: "public" }> => r.visibility === "public"
         )
-        .map((r) => renderPublicNote(r, publicSlugs, privateSlugs)),
+        .map((r) => renderPublicNote(r, publicSlugs, privateSlugs, assets))
     );
 
     return publicNotes;

--- a/lib/vault/adapter-local.ts
+++ b/lib/vault/adapter-local.ts
@@ -34,16 +34,17 @@ import matter from "gray-matter";
 import { walkVault } from "./walk";
 import { resolveVisibility } from "./fail-closed";
 import { VaultFrontmatterSchema } from "./schema";
-import type {
-  VaultNote,
-  VaultAdapter,
-  VaultFrontmatter,
-} from "./schema";
+import type { VaultNote, VaultAdapter, VaultFrontmatter } from "./schema";
 import { deriveSlug } from "./slug";
 import { applyPreviewDefaults } from "./preview-defaults";
 import { stripWikilinks } from "./wikilinks";
 import { renderMarkdown } from "./render";
 import { VaultParseError } from "./errors";
+import {
+  copyLocalVaultAsset,
+  rewriteMarkdownVaultImageRefs,
+  rewritePreviewVaultImage,
+} from "./assets";
 
 /** 1MB size cap on individual vault files. */
 const MAX_FILE_BYTES = 1024 * 1024;
@@ -72,10 +73,7 @@ type ResolvedFile =
  *
  * Throws `VaultParseError` for public-but-schema-invalid (P22).
  */
-async function resolveFile(
-  vaultRoot: string,
-  relPath: string,
-): Promise<ResolvedFile | null> {
+async function resolveFile(vaultRoot: string, relPath: string): Promise<ResolvedFile | null> {
   const absPath = path.join(vaultRoot, relPath);
   const filename = path.basename(relPath);
 
@@ -84,15 +82,13 @@ async function resolveFile(
   try {
     const s = await stat(absPath);
     if (s.size > MAX_FILE_BYTES) {
-      console.warn(
-        `[vault] Skipping ${relPath}: ${s.size} bytes exceeds ${MAX_FILE_BYTES}`,
-      );
+      console.warn(`[vault] Skipping ${relPath}: ${s.size} bytes exceeds ${MAX_FILE_BYTES}`);
       return null;
     }
     content = await readFile(absPath, "utf8");
   } catch (err) {
     console.error(
-      `[vault] Read error for ${relPath}: ${err instanceof Error ? err.message : String(err)}`,
+      `[vault] Read error for ${relPath}: ${err instanceof Error ? err.message : String(err)}`
     );
     return null;
   }
@@ -135,11 +131,7 @@ async function resolveFile(
   // Public: full schema parse so we know `title`/`date` exist before render.
   const parseResult = VaultFrontmatterSchema.safeParse(rawFrontmatter);
   if (!parseResult.success) {
-    throw new VaultParseError(
-      relPath,
-      "schema",
-      parseResult.error.issues[0]?.message,
-    );
+    throw new VaultParseError(relPath, "schema", parseResult.error.issues[0]?.message);
   }
 
   const frontmatter = parseResult.data as VaultFrontmatter;
@@ -199,18 +191,32 @@ function extractFirstParagraph(markdown: string): string {
  * wikilinks resolve into anchors (public) / throw (private) / strip (unknown).
  */
 async function renderPublicNote(
+  vaultRoot: string,
   resolved: Extract<ResolvedFile, { visibility: "public" }>,
   publicSlugs: ReadonlySet<string>,
-  privateSlugs: ReadonlySet<string>,
+  privateSlugs: ReadonlySet<string>
 ): Promise<VaultNote> {
-  const body = await renderMarkdown(resolved.bodyMarkdown, {
+  const bodyMarkdownForRender = await rewriteMarkdownVaultImageRefs(
+    resolved.bodyMarkdown,
+    resolved.relPath,
+    resolved.slug,
+    (asset) => copyLocalVaultAsset(vaultRoot, resolved.relPath, asset)
+  );
+
+  const body = await renderMarkdown(bodyMarkdownForRender, {
     publicSlugs,
     privateSlugs,
     sourcePath: resolved.relPath,
   });
 
   const firstParagraph = extractFirstParagraph(resolved.bodyMarkdown);
-  const preview = applyPreviewDefaults(resolved.frontmatter.preview, {
+  const previewInput = await rewritePreviewVaultImage(
+    resolved.frontmatter.preview,
+    resolved.relPath,
+    resolved.slug,
+    (asset) => copyLocalVaultAsset(vaultRoot, resolved.relPath, asset)
+  );
+  const preview = applyPreviewDefaults(previewInput, {
     title: resolved.frontmatter.title,
     firstParagraph,
   });
@@ -241,17 +247,12 @@ export class LocalVaultAdapter implements VaultAdapter {
           return await resolveFile(this.vaultRoot, relPath);
         } catch (err) {
           if (err instanceof VaultParseError) throw err;
-          console.error(
-            `[vault] Unexpected error resolving ${relPath}:`,
-            err,
-          );
+          console.error(`[vault] Unexpected error resolving ${relPath}:`, err);
           return null;
         }
-      }),
+      })
     );
-    const resolved = resolvedResults.filter(
-      (r): r is ResolvedFile => r !== null,
-    );
+    const resolved = resolvedResults.filter((r): r is ResolvedFile => r !== null);
 
     // Build slug sets for the leak gate
     const publicSlugs = new Set<string>();
@@ -269,10 +270,9 @@ export class LocalVaultAdapter implements VaultAdapter {
     const publicNotes = await Promise.all(
       resolved
         .filter(
-          (r): r is Extract<ResolvedFile, { visibility: "public" }> =>
-            r.visibility === "public",
+          (r): r is Extract<ResolvedFile, { visibility: "public" }> => r.visibility === "public"
         )
-        .map((r) => renderPublicNote(r, publicSlugs, privateSlugs)),
+        .map((r) => renderPublicNote(this.vaultRoot, r, publicSlugs, privateSlugs))
     );
 
     return publicNotes;

--- a/lib/vault/assets.ts
+++ b/lib/vault/assets.ts
@@ -1,0 +1,235 @@
+/**
+ * assets.ts — note-local vault asset resolution.
+ *
+ * Public notes may reference article-owned images with relative markdown paths
+ * such as `![alt](imgs/diagram.png)`. The vault remains the source of truth,
+ * while the portfolio serves a generated public copy at:
+ *
+ *   /vault-assets/<note-slug>/<path-under-imgs>
+ *
+ * Per P25: no I/O at module init. Copying happens only from adapter calls.
+ */
+
+import { copyFile, lstat, mkdir, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { VaultParseError } from "./errors";
+import type { PreviewConfigPartial } from "./schema";
+
+const ALLOWED_IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg"]);
+
+/** 10MB cap per generated/public vault image. */
+export const MAX_VAULT_ASSET_BYTES = 10 * 1024 * 1024;
+
+export interface ResolvedVaultAsset {
+  /** Vault-relative source path, e.g. notes/writing/imgs/foo.png. */
+  sourceRelPath: string;
+  /** Path under public/vault-assets/<slug>/, e.g. diagrams/foo.png. */
+  publicRelPath: string;
+  /** Browser path, e.g. /vault-assets/my-note/diagrams/foo.png. */
+  publicPath: string;
+}
+
+type EnsureAsset = (asset: ResolvedVaultAsset) => Promise<void>;
+
+function isExternalOrAbsoluteRef(src: string): boolean {
+  return src.startsWith("/") || src.startsWith("#") || /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(src);
+}
+
+function splitMarkdownDestination(raw: string): { src: string; suffix: string } {
+  const trimmed = raw.trim();
+  const wrapped = trimmed.match(/^<([^>]+)>(.*)$/);
+  if (wrapped) {
+    return { src: wrapped[1] ?? "", suffix: wrapped[2] ?? "" };
+  }
+
+  const titleStart = trimmed.search(/\s+["'(]/);
+  if (titleStart === -1) {
+    return { src: trimmed, suffix: "" };
+  }
+  return {
+    src: trimmed.slice(0, titleStart),
+    suffix: trimmed.slice(titleStart),
+  };
+}
+
+function hasAllowedImageExtension(relPath: string): boolean {
+  return ALLOWED_IMAGE_EXTENSIONS.has(path.posix.extname(relPath).toLowerCase());
+}
+
+export function isVaultAssetFile(relPath: string): boolean {
+  const normalized = path.posix.normalize(relPath);
+  return normalized.includes("/imgs/") && hasAllowedImageExtension(normalized);
+}
+
+export function resolveVaultAssetRef(
+  noteRelPath: string,
+  slug: string,
+  src: string
+): ResolvedVaultAsset | null {
+  const cleanSrc = src.trim();
+  if (!cleanSrc || isExternalOrAbsoluteRef(cleanSrc)) {
+    return null;
+  }
+
+  const noteDir = path.posix.dirname(noteRelPath);
+  const sourceRelPath = path.posix.normalize(path.posix.join(noteDir, cleanSrc));
+
+  if (
+    sourceRelPath.startsWith("../") ||
+    sourceRelPath === ".." ||
+    path.posix.isAbsolute(sourceRelPath)
+  ) {
+    return null;
+  }
+
+  const imgsToken = "/imgs/";
+  const imgsIndex = sourceRelPath.indexOf(imgsToken);
+  if (imgsIndex === -1 || !hasAllowedImageExtension(sourceRelPath)) {
+    return null;
+  }
+
+  const publicRelPath = sourceRelPath.slice(imgsIndex + imgsToken.length);
+  if (
+    !publicRelPath ||
+    publicRelPath.startsWith("../") ||
+    publicRelPath.includes("/../") ||
+    path.posix.isAbsolute(publicRelPath)
+  ) {
+    return null;
+  }
+
+  const encodedParts = publicRelPath
+    .split("/")
+    .filter(Boolean)
+    .map((part) => encodeURIComponent(part));
+
+  return {
+    sourceRelPath,
+    publicRelPath,
+    publicPath: `/vault-assets/${encodeURIComponent(slug)}/${encodedParts.join("/")}`,
+  };
+}
+
+export async function rewriteMarkdownVaultImageRefs(
+  markdown: string,
+  noteRelPath: string,
+  slug: string,
+  ensureAsset: EnsureAsset
+): Promise<string> {
+  const imagePattern = /!\[([^\]]*)\]\(([^)]+)\)/g;
+  let rewritten = "";
+  let lastIndex = 0;
+
+  for (const match of markdown.matchAll(imagePattern)) {
+    const [full, alt, rawDest] = match;
+    const index = match.index ?? 0;
+    rewritten += markdown.slice(lastIndex, index);
+
+    const { src, suffix } = splitMarkdownDestination(rawDest ?? "");
+    const asset = resolveVaultAssetRef(noteRelPath, slug, src);
+    if (asset) {
+      await ensureAsset(asset);
+      rewritten += `![${alt ?? ""}](${asset.publicPath}${suffix})`;
+    } else {
+      rewritten += full;
+    }
+
+    lastIndex = index + full.length;
+  }
+
+  rewritten += markdown.slice(lastIndex);
+  return rewritten;
+}
+
+export async function rewritePreviewVaultImage(
+  preview: PreviewConfigPartial | undefined,
+  noteRelPath: string,
+  slug: string,
+  ensureAsset: EnsureAsset
+): Promise<PreviewConfigPartial | undefined> {
+  if (!preview?.image) {
+    return preview;
+  }
+
+  const asset = resolveVaultAssetRef(noteRelPath, slug, preview.image);
+  if (!asset) {
+    return preview;
+  }
+
+  await ensureAsset(asset);
+  return {
+    ...preview,
+    image: asset.publicPath,
+  };
+}
+
+function vaultAssetOutputRoot(): string {
+  return path.join(process.cwd(), "public", "vault-assets");
+}
+
+function vaultAssetDestination(asset: ResolvedVaultAsset): string {
+  return path.join(vaultAssetOutputRoot(), asset.publicPath.replace(/^\/vault-assets\//, ""));
+}
+
+export async function copyLocalVaultAsset(
+  vaultRoot: string,
+  noteRelPath: string,
+  asset: ResolvedVaultAsset
+): Promise<void> {
+  const rootReal = await realpath(vaultRoot);
+  const sourceAbs = path.join(rootReal, asset.sourceRelPath);
+  const sourceStat = await lstat(sourceAbs).catch(() => null);
+
+  if (!sourceStat) {
+    throw new VaultParseError(noteRelPath, "asset", `missing image asset "${asset.sourceRelPath}"`);
+  }
+  if (sourceStat.isSymbolicLink() || !sourceStat.isFile()) {
+    throw new VaultParseError(
+      noteRelPath,
+      "asset",
+      `image asset must be a regular file: "${asset.sourceRelPath}"`
+    );
+  }
+  if (sourceStat.size > MAX_VAULT_ASSET_BYTES) {
+    throw new VaultParseError(
+      noteRelPath,
+      "asset",
+      `image asset too large: "${asset.sourceRelPath}" (${sourceStat.size} bytes)`
+    );
+  }
+
+  const sourceReal = await realpath(sourceAbs);
+  const normalizedRoot = rootReal.endsWith(path.sep) ? rootReal : rootReal + path.sep;
+  if (sourceReal !== rootReal && !sourceReal.startsWith(normalizedRoot)) {
+    throw new VaultParseError(
+      noteRelPath,
+      "asset",
+      `image asset escapes vault root: "${asset.sourceRelPath}"`
+    );
+  }
+
+  const destAbs = vaultAssetDestination(asset);
+  await mkdir(path.dirname(destAbs), { recursive: true });
+  await copyFile(sourceAbs, destAbs);
+}
+
+export async function writeBufferedVaultAsset(
+  noteRelPath: string,
+  asset: ResolvedVaultAsset,
+  buffer: Buffer | undefined
+): Promise<void> {
+  if (!buffer) {
+    throw new VaultParseError(noteRelPath, "asset", `missing image asset "${asset.sourceRelPath}"`);
+  }
+  if (buffer.byteLength > MAX_VAULT_ASSET_BYTES) {
+    throw new VaultParseError(
+      noteRelPath,
+      "asset",
+      `image asset too large: "${asset.sourceRelPath}" (${buffer.byteLength} bytes)`
+    );
+  }
+
+  const destAbs = vaultAssetDestination(asset);
+  await mkdir(path.dirname(destAbs), { recursive: true });
+  await writeFile(destAbs, buffer);
+}

--- a/lib/vault/assets.ts
+++ b/lib/vault/assets.ts
@@ -12,6 +12,8 @@
 
 import { copyFile, lstat, mkdir, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
 import { VaultParseError } from "./errors";
 import type { PreviewConfigPartial } from "./schema";
 
@@ -31,29 +33,48 @@ export interface ResolvedVaultAsset {
 
 type EnsureAsset = (asset: ResolvedVaultAsset) => Promise<void>;
 
+interface MarkdownNode {
+  type: string;
+  url?: unknown;
+  children?: MarkdownNode[];
+  position?: {
+    start?: { offset?: number };
+    end?: { offset?: number };
+  };
+}
+
+const markdownParser = unified().use(remarkParse).freeze();
+
 function isExternalOrAbsoluteRef(src: string): boolean {
   return src.startsWith("/") || src.startsWith("#") || /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(src);
 }
 
-function splitMarkdownDestination(raw: string): { src: string; suffix: string } {
-  const trimmed = raw.trim();
-  const wrapped = trimmed.match(/^<([^>]+)>(.*)$/);
-  if (wrapped) {
-    return { src: wrapped[1] ?? "", suffix: wrapped[2] ?? "" };
-  }
-
-  const titleStart = trimmed.search(/\s+["'(]/);
-  if (titleStart === -1) {
-    return { src: trimmed, suffix: "" };
-  }
-  return {
-    src: trimmed.slice(0, titleStart),
-    suffix: trimmed.slice(titleStart),
-  };
-}
-
 function hasAllowedImageExtension(relPath: string): boolean {
   return ALLOWED_IMAGE_EXTENSIONS.has(path.posix.extname(relPath).toLowerCase());
+}
+
+function visitMarkdownImages(node: MarkdownNode, visitor: (node: MarkdownNode) => void): void {
+  if (node.type === "image") {
+    visitor(node);
+  }
+
+  for (const child of node.children ?? []) {
+    visitMarkdownImages(child, visitor);
+  }
+}
+
+function replaceImageUrl(markdownSlice: string, oldUrl: string, newUrl: string): string {
+  for (const candidate of [`<${oldUrl}>`, oldUrl]) {
+    const index = markdownSlice.lastIndexOf(candidate);
+    if (index !== -1) {
+      const replacement = candidate.startsWith("<") ? `<${newUrl}>` : newUrl;
+      return `${markdownSlice.slice(0, index)}${replacement}${markdownSlice.slice(
+        index + candidate.length
+      )}`;
+    }
+  }
+
+  return markdownSlice;
 }
 
 export function isVaultAssetFile(relPath: string): boolean {
@@ -67,7 +88,7 @@ export function resolveVaultAssetRef(
   src: string
 ): ResolvedVaultAsset | null {
   const cleanSrc = src.trim();
-  if (!cleanSrc || isExternalOrAbsoluteRef(cleanSrc)) {
+  if (!cleanSrc || cleanSrc.includes("\\") || isExternalOrAbsoluteRef(cleanSrc)) {
     return null;
   }
 
@@ -116,28 +137,44 @@ export async function rewriteMarkdownVaultImageRefs(
   slug: string,
   ensureAsset: EnsureAsset
 ): Promise<string> {
-  const imagePattern = /!\[([^\]]*)\]\(([^)]+)\)/g;
-  let rewritten = "";
-  let lastIndex = 0;
+  const tree = markdownParser.parse(markdown) as MarkdownNode;
+  const replacements: Array<{
+    start: number;
+    end: number;
+    text: string;
+    asset: ResolvedVaultAsset;
+  }> = [];
 
-  for (const match of markdown.matchAll(imagePattern)) {
-    const [full, alt, rawDest] = match;
-    const index = match.index ?? 0;
-    rewritten += markdown.slice(lastIndex, index);
-
-    const { src, suffix } = splitMarkdownDestination(rawDest ?? "");
-    const asset = resolveVaultAssetRef(noteRelPath, slug, src);
-    if (asset) {
-      await ensureAsset(asset);
-      rewritten += `![${alt ?? ""}](${asset.publicPath}${suffix})`;
-    } else {
-      rewritten += full;
+  visitMarkdownImages(tree, (node) => {
+    const start = node.position?.start?.offset;
+    const end = node.position?.end?.offset;
+    if (typeof node.url !== "string" || start === undefined || end === undefined) {
+      return;
     }
 
-    lastIndex = index + full.length;
+    const asset = resolveVaultAssetRef(noteRelPath, slug, node.url);
+    if (!asset) {
+      return;
+    }
+
+    replacements.push({
+      start,
+      end,
+      asset,
+      text: replaceImageUrl(markdown.slice(start, end), node.url, asset.publicPath),
+    });
+  });
+
+  for (const replacement of replacements) {
+    await ensureAsset(replacement.asset);
   }
 
-  rewritten += markdown.slice(lastIndex);
+  let rewritten = markdown;
+  for (const replacement of replacements.sort((a, b) => b.start - a.start)) {
+    rewritten = `${rewritten.slice(0, replacement.start)}${replacement.text}${rewritten.slice(
+      replacement.end
+    )}`;
+  }
   return rewritten;
 }
 

--- a/lib/vault/errors.ts
+++ b/lib/vault/errors.ts
@@ -26,16 +26,10 @@ export class DuplicateSlugError extends Error {
   /** How each path in `paths` got its slug. */
   resolutions: ("derived" | "frontmatter")[];
 
-  constructor(
-    slug: string,
-    paths: string[],
-    resolutions: ("derived" | "frontmatter")[],
-  ) {
+  constructor(slug: string, paths: string[], resolutions: ("derived" | "frontmatter")[]) {
     super(
       `Duplicate slug "${slug}" across ${paths.length} notes:\n` +
-        paths
-          .map((p, i) => `  ${p} (${resolutions[i] ?? "derived"})`)
-          .join("\n"),
+        paths.map((p, i) => `  ${p} (${resolutions[i] ?? "derived"})`).join("\n")
     );
     this.name = "DuplicateSlugError";
     this.slug = slug;
@@ -55,7 +49,7 @@ export class VaultConfigError extends Error {
   constructor(missing: string[]) {
     super(
       `Vault configuration error — missing required env vars in production:\n` +
-        missing.map((v) => `  ${v}`).join("\n"),
+        missing.map((v) => `  ${v}`).join("\n")
     );
     this.name = "VaultConfigError";
     this.missing = missing;
@@ -86,7 +80,7 @@ export class WikilinkLeakError extends Error {
     super(
       `Wikilink leak: public note "${sourcePath}" links to "[[${target}]]" ` +
         `which resolves to private slug "${privateSlug}". ` +
-        `Either remove the link, mark the source note private, or mark the target note public.`,
+        `Either remove the link, mark the source note private, or mark the target note public.`
     );
     this.name = "WikilinkLeakError";
     this.sourcePath = sourcePath;
@@ -104,16 +98,10 @@ export class VaultParseError extends Error {
   /** Vault-relative file path. */
   path: string;
   /** Classification of the parse failure. */
-  reason: "yaml" | "schema" | "visibility";
+  reason: "yaml" | "schema" | "visibility" | "asset";
 
-  constructor(
-    path: string,
-    reason: "yaml" | "schema" | "visibility",
-    detail?: string,
-  ) {
-    super(
-      `Vault parse error in "${path}" (${reason})${detail ? ": " + detail : ""}`,
-    );
+  constructor(path: string, reason: "yaml" | "schema" | "visibility" | "asset", detail?: string) {
+    super(`Vault parse error in "${path}" (${reason})${detail ? ": " + detail : ""}`);
     this.name = "VaultParseError";
     this.path = path;
     this.reason = reason;

--- a/lib/vault/schema.ts
+++ b/lib/vault/schema.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 
 export type Visibility = "public" | "private";
 export type PreviewKind = "text" | "image" | "quote" | "embed";
+export type NoteType = "note" | "work" | "writing" | "reshare";
 
 // ── Sub-schemas ───────────────────────────────────────────────────────────────
 
@@ -65,20 +66,15 @@ export const VaultFrontmatterSchema = z
     title: z.string().min(1),
 
     date: z.preprocess(
-      (v) =>
-        v instanceof Date
-          ? v.toISOString().slice(0, 10)
-          : typeof v === "string"
-            ? v
-            : v,
-      z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD"),
+      (v) => (v instanceof Date ? v.toISOString().slice(0, 10) : typeof v === "string" ? v : v),
+      z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD")
     ),
 
     slug: z
       .string()
       .regex(
         /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/,
-        "slug must be kebab-case ASCII, starting and ending with alphanumeric",
+        "slug must be kebab-case ASCII, starting and ending with alphanumeric"
       )
       .optional(),
 
@@ -90,6 +86,12 @@ export const VaultFrontmatterSchema = z
     visibility: z.enum(["public", "private"]).default("private"),
 
     preview: PreviewConfigSchema.optional(),
+
+    /**
+     * `type` — content category. Defaults to `"note"` for legacy notes.
+     * `writing` and `reshare` are used by dy-journal article frontmatter.
+     */
+    type: z.enum(["note", "work", "writing", "reshare"]).default("note"),
   })
   .passthrough();
 

--- a/scripts/vault-lint.ts
+++ b/scripts/vault-lint.ts
@@ -23,9 +23,12 @@ import { readFileSync, readdirSync, lstatSync } from "fs";
 import type { Dirent } from "fs";
 import { join, relative, basename } from "path";
 import { load as yamlLoad } from "js-yaml";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
 import { resolveVisibility } from "../lib/vault/fail-closed.js";
 import { deriveSlug } from "../lib/vault/slug.js";
 import { VaultFrontmatterSchema } from "../lib/vault/schema.js";
+import type { VaultFrontmatter } from "../lib/vault/schema.js";
 import { resolveVaultAssetRef } from "../lib/vault/assets.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -62,6 +65,24 @@ interface LintOutput {
 interface ParseResult {
   frontmatter: unknown;
   parseError: string | null;
+}
+
+interface MarkdownNode {
+  type: string;
+  url?: unknown;
+  children?: MarkdownNode[];
+}
+
+const markdownParser = unified().use(remarkParse).freeze();
+
+function visitMarkdownImages(node: MarkdownNode, visitor: (node: MarkdownNode) => void): void {
+  if (node.type === "image") {
+    visitor(node);
+  }
+
+  for (const child of node.children ?? []) {
+    visitMarkdownImages(child, visitor);
+  }
 }
 
 /**
@@ -105,47 +126,27 @@ function parseFrontmatter(content: string): ParseResult {
 
 function collectMarkdownImageDests(markdown: string): string[] {
   const out: string[] = [];
-  const imagePattern = /!\[[^\]]*\]\(([^)]+)\)/g;
-  for (const match of markdown.matchAll(imagePattern)) {
-    const rawDest = (match[1] ?? "").trim();
-    const wrapped = rawDest.match(/^<([^>]+)>/);
-    if (wrapped?.[1]) {
-      out.push(wrapped[1]);
-      continue;
+  const tree = markdownParser.parse(markdown) as MarkdownNode;
+  visitMarkdownImages(tree, (node) => {
+    if (typeof node.url === "string") {
+      out.push(node.url);
     }
-    const titleStart = rawDest.search(/\s+["'(]/);
-    out.push(titleStart === -1 ? rawDest : rawDest.slice(0, titleStart));
-  }
+  });
   return out;
 }
 
-function previewImage(frontmatter: unknown): string | null {
-  if (frontmatter === null || typeof frontmatter !== "object" || Array.isArray(frontmatter)) {
-    return null;
-  }
-  const preview = (frontmatter as Record<string, unknown>)["preview"];
-  if (preview === null || typeof preview !== "object" || Array.isArray(preview)) {
-    return null;
-  }
-  const image = (preview as Record<string, unknown>)["image"];
-  return typeof image === "string" ? image : null;
+function previewImage(frontmatter: VaultFrontmatter): string | null {
+  return frontmatter.preview?.image ?? null;
 }
 
 function validatePublicImageAssets(
   filePath: string,
   vaultRoot: string,
   relPath: string,
-  frontmatter: unknown,
+  frontmatter: VaultFrontmatter,
   content: string
 ): LintError[] {
-  const frontmatterSlug =
-    frontmatter !== null &&
-    typeof frontmatter === "object" &&
-    !Array.isArray(frontmatter) &&
-    typeof (frontmatter as Record<string, unknown>)["slug"] === "string"
-      ? ((frontmatter as Record<string, unknown>)["slug"] as string)
-      : undefined;
-  const slug = deriveSlug(basename(filePath), frontmatterSlug);
+  const slug = deriveSlug(basename(filePath), frontmatter.slug);
   const refs = [...collectMarkdownImageDests(content)];
   const preview = previewImage(frontmatter);
   if (preview) refs.push(preview);
@@ -367,7 +368,9 @@ function lintFile(
     };
   }
 
-  errors.push(...validatePublicImageAssets(filePath, vaultRoot, relPath, frontmatter, content));
+  errors.push(
+    ...validatePublicImageAssets(filePath, vaultRoot, relPath, schemaResult.data, content)
+  );
 
   if (errors.length > 0) {
     return {

--- a/scripts/vault-lint.ts
+++ b/scripts/vault-lint.ts
@@ -26,6 +26,7 @@ import { load as yamlLoad } from "js-yaml";
 import { resolveVisibility } from "../lib/vault/fail-closed.js";
 import { deriveSlug } from "../lib/vault/slug.js";
 import { VaultFrontmatterSchema } from "../lib/vault/schema.js";
+import { resolveVaultAssetRef } from "../lib/vault/assets.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -39,7 +40,7 @@ interface FileResult {
 
 interface LintError {
   path: string;
-  kind: "duplicate-slug" | "schema" | "yaml" | "io" | "args";
+  kind: "duplicate-slug" | "schema" | "yaml" | "io" | "args" | "asset";
   message: string;
 }
 
@@ -100,6 +101,83 @@ function parseFrontmatter(content: string): ParseResult {
     const message = err instanceof Error ? err.message : String(err);
     return { frontmatter: null, parseError: message };
   }
+}
+
+function collectMarkdownImageDests(markdown: string): string[] {
+  const out: string[] = [];
+  const imagePattern = /!\[[^\]]*\]\(([^)]+)\)/g;
+  for (const match of markdown.matchAll(imagePattern)) {
+    const rawDest = (match[1] ?? "").trim();
+    const wrapped = rawDest.match(/^<([^>]+)>/);
+    if (wrapped?.[1]) {
+      out.push(wrapped[1]);
+      continue;
+    }
+    const titleStart = rawDest.search(/\s+["'(]/);
+    out.push(titleStart === -1 ? rawDest : rawDest.slice(0, titleStart));
+  }
+  return out;
+}
+
+function previewImage(frontmatter: unknown): string | null {
+  if (frontmatter === null || typeof frontmatter !== "object" || Array.isArray(frontmatter)) {
+    return null;
+  }
+  const preview = (frontmatter as Record<string, unknown>)["preview"];
+  if (preview === null || typeof preview !== "object" || Array.isArray(preview)) {
+    return null;
+  }
+  const image = (preview as Record<string, unknown>)["image"];
+  return typeof image === "string" ? image : null;
+}
+
+function validatePublicImageAssets(
+  filePath: string,
+  vaultRoot: string,
+  relPath: string,
+  frontmatter: unknown,
+  content: string
+): LintError[] {
+  const frontmatterSlug =
+    frontmatter !== null &&
+    typeof frontmatter === "object" &&
+    !Array.isArray(frontmatter) &&
+    typeof (frontmatter as Record<string, unknown>)["slug"] === "string"
+      ? ((frontmatter as Record<string, unknown>)["slug"] as string)
+      : undefined;
+  const slug = deriveSlug(basename(filePath), frontmatterSlug);
+  const refs = [...collectMarkdownImageDests(content)];
+  const preview = previewImage(frontmatter);
+  if (preview) refs.push(preview);
+
+  const errors: LintError[] = [];
+  for (const ref of refs) {
+    const asset = resolveVaultAssetRef(relPath, slug, ref);
+    if (!asset) continue;
+
+    const assetPath = join(vaultRoot, asset.sourceRelPath);
+    let assetStat: ReturnType<typeof lstatSync>;
+    try {
+      assetStat = lstatSync(assetPath);
+    } catch {
+      errors.push({
+        path: relPath,
+        kind: "asset",
+        message: `missing image asset: ${asset.sourceRelPath}`,
+      });
+      continue;
+    }
+
+    if (!assetStat.isFile() || assetStat.isSymbolicLink()) {
+      errors.push({
+        path: relPath,
+        kind: "asset",
+        message: `image asset must be a regular file: ${asset.sourceRelPath}`,
+      });
+    }
+  }
+
+  return errors;
 }
 
 // ── Vault walker ──────────────────────────────────────────────────────────────
@@ -198,7 +276,7 @@ function walkVault(dir: string): WalkResult {
  */
 function lintFile(
   filePath: string,
-  vaultRoot: string,
+  vaultRoot: string
 ): { result: FileResult; errors: LintError[]; frontmatter: unknown } {
   const relPath = relative(vaultRoot, filePath);
   const errors: LintError[] = [];
@@ -289,6 +367,20 @@ function lintFile(
     };
   }
 
+  errors.push(...validatePublicImageAssets(filePath, vaultRoot, relPath, frontmatter, content));
+
+  if (errors.length > 0) {
+    return {
+      result: {
+        path: relPath,
+        status: "error",
+        reason: errors.map((err) => err.message).join("; "),
+      },
+      errors,
+      frontmatter,
+    };
+  }
+
   return { result: { path: relPath, status: "public" }, errors, frontmatter };
 }
 
@@ -331,11 +423,7 @@ function lintVault(vaultPath: string): LintOutput {
     // instead of re-reading the file. (gemini + copilot #45)
     if (result.status !== "error") {
       let frontmatterSlug: string | undefined;
-      if (
-        frontmatter !== null &&
-        typeof frontmatter === "object" &&
-        !Array.isArray(frontmatter)
-      ) {
+      if (frontmatter !== null && typeof frontmatter === "object" && !Array.isArray(frontmatter)) {
         const fm = frontmatter as Record<string, unknown>;
         if (typeof fm["slug"] === "string") {
           frontmatterSlug = fm["slug"];
@@ -433,9 +521,7 @@ export function main(argv: string[]): number {
   if (parsed.kind === "error") {
     process.stderr.write(parsed.message + "\n");
     if (!parsed.message.startsWith("Usage:")) {
-      process.stderr.write(
-        "Usage: vault-lint [--report] [--json] <vault-path>\n",
-      );
+      process.stderr.write("Usage: vault-lint [--report] [--json] <vault-path>\n");
     }
     return 1;
   }
@@ -454,15 +540,18 @@ export function main(argv: string[]): number {
 
   if (report) {
     // --report: list every file with status and reason
+    process.stderr.write(`vault-lint report — walked ${summary.walked} files\n`);
     process.stderr.write(
-      `vault-lint report — walked ${summary.walked} files\n`,
-    );
-    process.stderr.write(
-      `  public: ${summary.public}  private: ${summary.private}  errors: ${summary.errors}\n\n`,
+      `  public: ${summary.public}  private: ${summary.private}  errors: ${summary.errors}\n\n`
     );
 
     for (const file of files) {
-      const tag = file.status === "public" ? "[public] " : file.status === "private" ? "[private]" : "[error]  ";
+      const tag =
+        file.status === "public"
+          ? "[public] "
+          : file.status === "private"
+            ? "[private]"
+            : "[error]  ";
       const reason = file.reason !== undefined ? `  — ${file.reason}` : "";
       process.stderr.write(`  ${tag}  ${file.path}${reason}\n`);
     }
@@ -485,7 +574,7 @@ export function main(argv: string[]): number {
   const ok = errors.length === 0;
   if (!report && !json && ok) {
     process.stderr.write(
-      `vault-lint: ${summary.walked} files walked, ${summary.public} public, ${summary.private} private — OK\n`,
+      `vault-lint: ${summary.walked} files walked, ${summary.public} public, ${summary.private} private — OK\n`
     );
   }
 

--- a/test/vault/assets.test.ts
+++ b/test/vault/assets.test.ts
@@ -10,6 +10,7 @@ import * as path from "node:path";
 import * as tar from "tar";
 import { LocalVaultAdapter } from "../../lib/vault/adapter-local";
 import { GitHubVaultAdapter } from "../../lib/vault/adapter-github";
+import { resolveVaultAssetRef, rewriteMarkdownVaultImageRefs } from "../../lib/vault/assets";
 import { VaultParseError } from "../../lib/vault/errors";
 
 const NOTE_WITH_IMAGE = `---
@@ -83,6 +84,36 @@ describe("vault asset pipeline — local adapter", () => {
         reason: "asset",
       } satisfies Partial<VaultParseError>);
     });
+  });
+
+  it("rejects backslash traversal references before local path joins see them", () => {
+    expect(
+      resolveVaultAssetRef("notes/writing/post.md", "post", "..\\..\\private\\imgs\\x.svg")
+    ).toBeNull();
+  });
+
+  it("rewrites image urls with parentheses and ignores image-looking code blocks", async () => {
+    const seen: string[] = [];
+    const markdown = [
+      '![Hero](imgs/hero(1).svg "Hero title")',
+      "",
+      "```md",
+      "![Code](imgs/code.svg)",
+      "```",
+    ].join("\n");
+
+    const rewritten = await rewriteMarkdownVaultImageRefs(
+      markdown,
+      "notes/writing/asset-note.md",
+      "asset-note",
+      async (asset) => {
+        seen.push(asset.sourceRelPath);
+      }
+    );
+
+    expect(rewritten).toContain('![Hero](/vault-assets/asset-note/hero(1).svg "Hero title")');
+    expect(rewritten).toContain("![Code](imgs/code.svg)");
+    expect(seen).toEqual(["notes/writing/imgs/hero(1).svg"]);
   });
 });
 

--- a/test/vault/assets.test.ts
+++ b/test/vault/assets.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment node
+/**
+ * assets.test.ts — note-local vault image pipeline tests.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as tar from "tar";
+import { LocalVaultAdapter } from "../../lib/vault/adapter-local";
+import { GitHubVaultAdapter } from "../../lib/vault/adapter-github";
+import { VaultParseError } from "../../lib/vault/errors";
+
+const NOTE_WITH_IMAGE = `---
+title: Asset Note
+date: 2026-05-29
+visibility: public
+preview:
+  kind: image
+  image: imgs/hero.svg
+---
+
+Intro paragraph.
+
+![Hero diagram](imgs/hero.svg)
+`;
+
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="#ffef00"/></svg>`;
+
+async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    return await fn(dir);
+  } finally {
+    await fsp.rm(dir, { recursive: true, force: true });
+  }
+}
+
+afterEach(async () => {
+  await fsp.rm(path.resolve("public", "vault-assets", "asset-note"), {
+    recursive: true,
+    force: true,
+  });
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("vault asset pipeline — local adapter", () => {
+  it("rewrites note-local markdown and preview images to /vault-assets and copies the asset", async () => {
+    await withTempDir("vault-assets-local-", async (tmp) => {
+      const vaultRoot = path.join(tmp, "vault");
+      const outRoot = path.resolve("public", "vault-assets");
+
+      await fsp.mkdir(path.join(vaultRoot, "notes", "writing", "imgs"), { recursive: true });
+      await fsp.writeFile(
+        path.join(vaultRoot, "notes", "writing", "asset-note.md"),
+        NOTE_WITH_IMAGE
+      );
+      await fsp.writeFile(path.join(vaultRoot, "notes", "writing", "imgs", "hero.svg"), SVG);
+
+      const notes = await new LocalVaultAdapter(vaultRoot).getPublicNotes();
+      expect(notes).toHaveLength(1);
+      expect(notes[0].body).toContain('src="/vault-assets/asset-note/hero.svg"');
+      expect(notes[0].preview.image).toBe("/vault-assets/asset-note/hero.svg");
+      await expect(
+        fsp.readFile(path.join(outRoot, "asset-note", "hero.svg"), "utf8")
+      ).resolves.toContain("<svg");
+    });
+  });
+
+  it("fails loudly when a public note references a missing note-local image", async () => {
+    await withTempDir("vault-assets-missing-", async (tmp) => {
+      const vaultRoot = path.join(tmp, "vault");
+      await fsp.mkdir(path.join(vaultRoot, "notes", "writing"), { recursive: true });
+      await fsp.writeFile(
+        path.join(vaultRoot, "notes", "writing", "asset-note.md"),
+        NOTE_WITH_IMAGE
+      );
+
+      await expect(new LocalVaultAdapter(vaultRoot).getPublicNotes()).rejects.toMatchObject({
+        name: "VaultParseError",
+        reason: "asset",
+      } satisfies Partial<VaultParseError>);
+    });
+  });
+});
+
+async function createTarball(
+  entries: Array<{ relativePath: string; content: string | Buffer }>
+): Promise<Buffer> {
+  return await withTempDir("vault-assets-gh-src-", async (tmp) => {
+    const prefix = "owner-repo-sha123";
+    await fsp.mkdir(path.join(tmp, prefix), { recursive: true });
+    for (const entry of entries) {
+      const full = path.join(tmp, prefix, entry.relativePath);
+      await fsp.mkdir(path.dirname(full), { recursive: true });
+      await fsp.writeFile(full, entry.content);
+    }
+    const tarPath = path.join(tmp, "out.tar.gz");
+    await tar.c({ gzip: true, cwd: tmp, file: tarPath }, [prefix]);
+    return await fsp.readFile(tarPath);
+  });
+}
+
+function mockFetch(tarball: Buffer) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: () =>
+        Promise.resolve(
+          tarball.buffer.slice(tarball.byteOffset, tarball.byteOffset + tarball.byteLength)
+        ),
+    })
+  );
+}
+
+describe("vault asset pipeline — GitHub adapter", () => {
+  it("collects tarball image assets and writes public /vault-assets copies", async () => {
+    await withTempDir("vault-assets-gh-", async () => {
+      const outRoot = path.resolve("public", "vault-assets");
+      const tarball = await createTarball([
+        { relativePath: "notes/writing/asset-note.md", content: NOTE_WITH_IMAGE },
+        { relativePath: "notes/writing/imgs/hero.svg", content: SVG },
+      ]);
+      mockFetch(tarball);
+
+      const notes = await new GitHubVaultAdapter({
+        owner: "o",
+        repo: "r",
+        token: "t",
+      }).getPublicNotes();
+      expect(notes).toHaveLength(1);
+      expect(notes[0].body).toContain('src="/vault-assets/asset-note/hero.svg"');
+      await expect(
+        fsp.readFile(path.join(outRoot, "asset-note", "hero.svg"), "utf8")
+      ).resolves.toContain("<svg");
+    });
+  });
+});

--- a/test/vault/duplicate-check.test.ts
+++ b/test/vault/duplicate-check.test.ts
@@ -15,6 +15,7 @@ function makeNote(slug: string, filepath: string, frontmatterSlug?: string): Vau
       title: "Test Note",
       date: "2026-05-10",
       visibility: "public",
+      type: "note",
       ...(frontmatterSlug ? { slug: frontmatterSlug } : {}),
     },
     body: "<p>body</p>",
@@ -49,18 +50,12 @@ describe("assertNoDuplicateSlugs — no collision", () => {
 
 describe("assertNoDuplicateSlugs — 2-way collision", () => {
   it("throws DuplicateSlugError for 2 notes with the same slug", () => {
-    const notes = [
-      makeNote("my-note", "note-a.md"),
-      makeNote("my-note", "note-b.md"),
-    ];
+    const notes = [makeNote("my-note", "note-a.md"), makeNote("my-note", "note-b.md")];
     expect(() => assertNoDuplicateSlugs(notes)).toThrow(DuplicateSlugError);
   });
 
   it("error contains the colliding slug", () => {
-    const notes = [
-      makeNote("my-note", "note-a.md"),
-      makeNote("my-note", "note-b.md"),
-    ];
+    const notes = [makeNote("my-note", "note-a.md"), makeNote("my-note", "note-b.md")];
     try {
       assertNoDuplicateSlugs(notes);
     } catch (err) {
@@ -70,10 +65,7 @@ describe("assertNoDuplicateSlugs — 2-way collision", () => {
   });
 
   it("error contains both colliding paths", () => {
-    const notes = [
-      makeNote("my-note", "note-a.md"),
-      makeNote("my-note", "note-b.md"),
-    ];
+    const notes = [makeNote("my-note", "note-a.md"), makeNote("my-note", "note-b.md")];
     try {
       assertNoDuplicateSlugs(notes);
     } catch (err) {
@@ -115,11 +107,7 @@ describe("assertNoDuplicateSlugs — 3-way collision (N-way)", () => {
   });
 
   it("error resolutions array has same length as paths", () => {
-    const notes = [
-      makeNote("dup", "a.md"),
-      makeNote("dup", "b.md"),
-      makeNote("dup", "c.md"),
-    ];
+    const notes = [makeNote("dup", "a.md"), makeNote("dup", "b.md"), makeNote("dup", "c.md")];
     try {
       assertNoDuplicateSlugs(notes);
     } catch (err) {

--- a/test/vault/vault-lint.test.ts
+++ b/test/vault/vault-lint.test.ts
@@ -164,6 +164,30 @@ describe("vault-lint CLI", () => {
       expect(stderr).not.toMatch(/README\.md/);
       expect(stderr).not.toMatch(/duplicate-slug/);
     });
+
+    it("validates markdown image urls with parentheses without scanning code blocks", () => {
+      const vault = makeVault({
+        "article.md": `---
+title: Article
+date: 2026-05-10
+visibility: public
+---
+
+![Hero](imgs/hero(1).svg)
+
+\`\`\`md
+![Missing](imgs/missing.svg)
+\`\`\`
+`,
+      });
+      mkdirSync(join(vault, "notes", "imgs"), { recursive: true });
+      writeFileSync(join(vault, "notes", "imgs", "hero(1).svg"), "<svg />", "utf-8");
+
+      const { code, stderr } = withCapture(() => main(["node", "vault-lint.ts", vault]));
+
+      expect(code).toBe(0);
+      expect(stderr).not.toMatch(/missing image asset/);
+    });
   });
 
   describe("duplicate slug detection", () => {

--- a/test/vault/vault-lint.test.ts
+++ b/test/vault/vault-lint.test.ts
@@ -112,10 +112,7 @@ function makeVault(notes: Record<string, string>): string {
 // ── Test setup ────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
-  tmpDir = join(
-    tmpdir(),
-    `vault-lint-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  );
+  tmpDir = join(tmpdir(), `vault-lint-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(tmpDir, { recursive: true });
 });
 
@@ -134,9 +131,7 @@ describe("vault-lint CLI", () => {
         "no-vis.md": NO_VISIBILITY,
       });
 
-      const { code } = withCapture(() =>
-        main(["node", "vault-lint.ts", vault]),
-      );
+      const { code } = withCapture(() => main(["node", "vault-lint.ts", vault]));
 
       expect(code).toBe(0);
     });
@@ -146,9 +141,7 @@ describe("vault-lint CLI", () => {
         "hello-world.md": VALID_PUBLIC(),
       });
 
-      const { code, stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", vault]),
-      );
+      const { code, stderr } = withCapture(() => main(["node", "vault-lint.ts", vault]));
 
       expect(code).toBe(0);
       expect(stderr).not.toMatch(/\[schema\]|\[yaml\]|\[duplicate-slug\]/);
@@ -162,7 +155,7 @@ describe("vault-lint CLI", () => {
       writeFileSync(join(vault, "README.md"), VALID_PUBLIC("Root Readme"), "utf-8");
 
       const { code, stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--report", vault]),
+        main(["node", "vault-lint.ts", "--report", vault])
       );
 
       expect(code).toBe(0);
@@ -181,9 +174,7 @@ describe("vault-lint CLI", () => {
         "Hello World.md": VALID_PUBLIC("Hello World Dupe"),
       });
 
-      const { code } = withCapture(() =>
-        main(["node", "vault-lint.ts", vault]),
-      );
+      const { code } = withCapture(() => main(["node", "vault-lint.ts", vault]));
 
       expect(code).toBe(1);
     });
@@ -194,9 +185,7 @@ describe("vault-lint CLI", () => {
         "Hello World.md": VALID_PUBLIC("Hello World Dupe"),
       });
 
-      const { stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", vault]),
-      );
+      const { stderr } = withCapture(() => main(["node", "vault-lint.ts", vault]));
 
       expect(stderr).toMatch(/duplicate-slug|duplicate slug/i);
       expect(stderr).toMatch(/hello-world/);
@@ -217,9 +206,7 @@ Body.
         "other-note.md": withSlugOverride,
       });
 
-      const { code } = withCapture(() =>
-        main(["node", "vault-lint.ts", vault]),
-      );
+      const { code } = withCapture(() => main(["node", "vault-lint.ts", vault]));
 
       expect(code).toBe(1);
     });
@@ -232,9 +219,7 @@ Body.
         "malformed.md": MALFORMED_YAML,
       });
 
-      const { code } = withCapture(() =>
-        main(["node", "vault-lint.ts", vault]),
-      );
+      const { code } = withCapture(() => main(["node", "vault-lint.ts", vault]));
 
       expect(code).toBe(1);
     });
@@ -244,9 +229,7 @@ Body.
         "malformed.md": MALFORMED_YAML,
       });
 
-      const { stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", vault]),
-      );
+      const { stderr } = withCapture(() => main(["node", "vault-lint.ts", vault]));
 
       expect(stderr).toMatch(/\[yaml\]/);
     });
@@ -263,9 +246,7 @@ No title field — schema should fail, resolves to private.
         "no-title.md": missingTitle,
       });
 
-      const { code } = withCapture(() =>
-        main(["node", "vault-lint.ts", vault]),
-      );
+      const { code } = withCapture(() => main(["node", "vault-lint.ts", vault]));
 
       // Missing title on public note → schema error → exit 1
       // (resolveVisibility returns 'private' since schema fails → no error from lint)
@@ -283,9 +264,7 @@ No title field — schema should fail, resolves to private.
         "no-vis.md": NO_VISIBILITY,
       });
 
-      const { stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--report", vault]),
-      );
+      const { stderr } = withCapture(() => main(["node", "vault-lint.ts", "--report", vault]));
 
       expect(stderr).toMatch(/public-note\.md/);
       expect(stderr).toMatch(/private-note\.md/);
@@ -297,9 +276,7 @@ No title field — schema should fail, resolves to private.
         "my-post.md": VALID_PUBLIC(),
       });
 
-      const { stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--report", vault]),
-      );
+      const { stderr } = withCapture(() => main(["node", "vault-lint.ts", "--report", vault]));
 
       expect(stderr).toMatch(/\[public\]/i);
       expect(stderr).toMatch(/my-post\.md/);
@@ -310,9 +287,7 @@ No title field — schema should fail, resolves to private.
         "private.md": VALID_PRIVATE,
       });
 
-      const { stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--report", vault]),
-      );
+      const { stderr } = withCapture(() => main(["node", "vault-lint.ts", "--report", vault]));
 
       expect(stderr).toMatch(/\[private\]/i);
       expect(stderr).toMatch(/private\.md/);
@@ -323,9 +298,7 @@ No title field — schema should fail, resolves to private.
         "post.md": VALID_PUBLIC(),
       });
 
-      const { code } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--report", vault]),
-      );
+      const { code } = withCapture(() => main(["node", "vault-lint.ts", "--report", vault]));
 
       expect(code).toBe(0);
     });
@@ -338,7 +311,7 @@ No title field — schema should fail, resolves to private.
       });
 
       const { code, stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--report", vault]),
+        main(["node", "vault-lint.ts", "--report", vault])
       );
 
       expect(code).toBe(1);
@@ -353,9 +326,7 @@ No title field — schema should fail, resolves to private.
         "private.md": VALID_PRIVATE,
       });
 
-      const { stdout } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--json", vault]),
-      );
+      const { stdout } = withCapture(() => main(["node", "vault-lint.ts", "--json", vault]));
 
       const parsed = JSON.parse(stdout) as unknown;
       expect(parsed).toBeTruthy();
@@ -367,9 +338,7 @@ No title field — schema should fail, resolves to private.
         "private.md": VALID_PRIVATE,
       });
 
-      const { stdout } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--json", vault]),
-      );
+      const { stdout } = withCapture(() => main(["node", "vault-lint.ts", "--json", vault]));
 
       const result = JSON.parse(stdout) as {
         summary: { walked: number; public: number; private: number; errors: number };
@@ -399,9 +368,7 @@ No title field — schema should fail, resolves to private.
         "hello.md": VALID_PUBLIC(),
       });
 
-      const { stdout } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--json", vault]),
-      );
+      const { stdout } = withCapture(() => main(["node", "vault-lint.ts", "--json", vault]));
 
       // The only stdout content should be parseable JSON
       expect(() => JSON.parse(stdout)).not.toThrow();
@@ -416,9 +383,7 @@ No title field — schema should fail, resolves to private.
         "priv.md": VALID_PRIVATE,
       });
 
-      const { stdout } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--json", vault]),
-      );
+      const { stdout } = withCapture(() => main(["node", "vault-lint.ts", "--json", vault]));
 
       const result = JSON.parse(stdout) as {
         summary: { walked: number; public: number; private: number; errors: number };
@@ -439,9 +404,7 @@ No title field — schema should fail, resolves to private.
         "Hello World.md": VALID_PUBLIC("Note A Dup"),
       });
 
-      const { code, stdout } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--json", vault]),
-      );
+      const { code, stdout } = withCapture(() => main(["node", "vault-lint.ts", "--json", vault]));
 
       const result = JSON.parse(stdout) as {
         errors: Array<{ kind: string; path: string; message: string }>;
@@ -456,9 +419,7 @@ No title field — schema should fail, resolves to private.
         "hello.md": VALID_PUBLIC(),
       });
 
-      const { stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--json", vault]),
-      );
+      const { stderr } = withCapture(() => main(["node", "vault-lint.ts", "--json", vault]));
 
       // No human-readable summary lines in stderr for json mode
       expect(stderr).not.toMatch(/vault-lint:/);
@@ -483,7 +444,7 @@ No title field — schema should fail, resolves to private.
       writeFileSync(join(trashDir, "deleted.md"), MALFORMED_YAML, "utf-8");
 
       const { code, stdout } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--json", vaultDir]),
+        main(["node", "vault-lint.ts", "--json", vaultDir])
       );
 
       // Only the one note in notes/ should be walked; no errors from hidden dirs
@@ -502,9 +463,7 @@ No title field — schema should fail, resolves to private.
         "note.md": VALID_PUBLIC(),
       });
 
-      const { code: cleanCode } = withCapture(() =>
-        main(["node", "vault-lint.ts", cleanVault]),
-      );
+      const { code: cleanCode } = withCapture(() => main(["node", "vault-lint.ts", cleanVault]));
       expect(cleanCode).toBe(0);
 
       const dupVault = makeVault({
@@ -513,9 +472,7 @@ No title field — schema should fail, resolves to private.
         "Hello World.md": VALID_PUBLIC("Note Dup"),
       });
 
-      const { code: errCode } = withCapture(() =>
-        main(["node", "vault-lint.ts", dupVault]),
-      );
+      const { code: errCode } = withCapture(() => main(["node", "vault-lint.ts", dupVault]));
       expect(errCode).toBe(1);
     });
   });
@@ -526,15 +483,9 @@ No title field — schema should fail, resolves to private.
       // (a fail-closed regression fixture). vault-lint correctly returns
       // exit 1 because that note has a YAML parse error — that's the
       // intended behavior, not a regression.
-      const fixtureVault = join(
-        process.cwd(),
-        "__fixtures__",
-        "vault",
-      );
+      const fixtureVault = join(process.cwd(), "__fixtures__", "vault");
 
-      const { code, stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", fixtureVault]),
-      );
+      const { code, stderr } = withCapture(() => main(["node", "vault-lint.ts", fixtureVault]));
 
       expect(code).toBe(1);
       expect(stderr).toMatch(/malformed-frontmatter/);
@@ -547,13 +498,8 @@ No title field — schema should fail, resolves to private.
   describe("regressions (PR #45 review)", () => {
     it("rejects opening --- without closing fence as YAML error (copilot #45)", () => {
       const v = makeVault({});
-      writeFileSync(
-        join(v, "notes", "broken.md"),
-        "---\ntitle: Broken\nvisibility: public\n",
-      );
-      const { code, stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", v]),
-      );
+      writeFileSync(join(v, "notes", "broken.md"), "---\ntitle: Broken\nvisibility: public\n");
+      const { code, stderr } = withCapture(() => main(["node", "vault-lint.ts", v]));
       expect(code).toBe(1);
       expect(stderr).toMatch(/yaml/i);
     });
@@ -562,47 +508,37 @@ No title field — schema should fail, resolves to private.
       const v = makeVault({});
       writeFileSync(
         join(v, "notes", "hello.md"),
-        "---\ntitle: A\ndate: 2026-05-10\nvisibility: public\nslug: shared\n---\n",
+        "---\ntitle: A\ndate: 2026-05-10\nvisibility: public\nslug: shared\n---\n"
       );
       writeFileSync(
         join(v, "notes", "world.md"),
-        "---\ntitle: B\ndate: 2026-05-11\nvisibility: public\nslug: shared\n---\n",
+        "---\ntitle: B\ndate: 2026-05-11\nvisibility: public\nslug: shared\n---\n"
       );
-      const { code, stdout } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--json", v]),
-      );
+      const { code, stdout } = withCapture(() => main(["node", "vault-lint.ts", "--json", v]));
       expect(code).toBe(1);
       const out = JSON.parse(stdout) as {
         files: { path: string; status: string }[];
         errors: { path: string; kind: string }[];
       };
       const errPaths = new Set(
-        out.errors
-          .filter((e) => e.kind === "duplicate-slug")
-          .map((e) => e.path),
+        out.errors.filter((e) => e.kind === "duplicate-slug").map((e) => e.path)
       );
       expect(errPaths.has("notes/hello.md")).toBe(true);
       expect(errPaths.has("notes/world.md")).toBe(true);
-      const fileStatuses = Object.fromEntries(
-        out.files.map((f) => [f.path, f.status]),
-      );
+      const fileStatuses = Object.fromEntries(out.files.map((f) => [f.path, f.status]));
       expect(fileStatuses["notes/hello.md"]).toBe("error");
       expect(fileStatuses["notes/world.md"]).toBe("error");
     });
 
     it("treats non-existent vault path as walk error, not silent OK (copilot #45)", () => {
       const ghostPath = join(tmpdir(), "vault-lint-ghost-" + Date.now());
-      const { code, stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", ghostPath]),
-      );
+      const { code, stderr } = withCapture(() => main(["node", "vault-lint.ts", ghostPath]));
       expect(code).toBe(1);
       expect(stderr.toLowerCase()).toMatch(/io|walk|directory|enoent/);
     });
 
     it("returns exit 1 (not process.exit) on bad args (gemini #45)", () => {
-      const { code, stderr } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--unknown-flag"]),
-      );
+      const { code, stderr } = withCapture(() => main(["node", "vault-lint.ts", "--unknown-flag"]));
       expect(code).toBe(1);
       expect(stderr).toMatch(/Unknown flag|Usage/);
     });
@@ -612,22 +548,17 @@ No title field — schema should fail, resolves to private.
       const v = makeVault({});
       writeFileSync(
         join(v, "notes", "real.md"),
-        "---\ntitle: Real\ndate: 2026-05-10\nvisibility: public\n---\n",
+        "---\ntitle: Real\ndate: 2026-05-10\nvisibility: public\n---\n"
       );
       // Create a symlink pointing to a target that exists
       try {
-        symlinkSync(
-          join(v, "notes", "real.md"),
-          join(v, "notes", "symlink-to-real.md"),
-        );
+        symlinkSync(join(v, "notes", "real.md"), join(v, "notes", "symlink-to-real.md"));
       } catch {
         // Skip on platforms / FS that don't support symlinks
         return;
       }
       if (!existsSync(join(v, "notes", "symlink-to-real.md"))) return;
-      const { code, stdout } = withCapture(() =>
-        main(["node", "vault-lint.ts", "--json", v]),
-      );
+      const { code, stdout } = withCapture(() => main(["node", "vault-lint.ts", "--json", v]));
       expect(code).toBe(0);
       const out = JSON.parse(stdout) as {
         files: { path: string }[];


### PR DESCRIPTION
## Summary
- stacks this vault asset pipeline on top of `checkpoint/about-page-current-state` (the branch that merged #61)
- rewrite note-local markdown image refs like `imgs/foo.svg` to served `/vault-assets/<slug>/foo.svg`
- copy referenced vault images from local/GitHub adapters into `public/vault-assets` during build
- validate missing note-local public image refs in `vault-lint`
- allow `type: writing` / `type: reshare` so dy-journal public articles render instead of being treated private
- address Gemini review feedback: reject backslash traversal refs, use remark AST image traversal instead of raw regex matching, preserve image URLs with parentheses, and avoid scanning code blocks

## Verification
- `npm exec -- eslint lib/vault/assets.ts scripts/vault-lint.ts test/vault/assets.test.ts test/vault/vault-lint.test.ts`
- `npm run typecheck`
- `npm test -- --run test/vault/assets.test.ts test/vault/vault-lint.test.ts`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run leak-test`

## Notes
- `npm run lint` passes with existing warnings only.
- The dy-journal PR owns the migrated `context-is-the-constraint.svg` asset plus markdown placement marker.
- `vault-lint --report /tmp/dy-journal-audit` still reports pre-existing duplicate `AGENTS` slugs unrelated to this asset work.
