### PR TITLE
fix(mobile): polish homepage cleanup layout

### DIFF
--- a/components/SiteNav.tsx
+++ b/components/SiteNav.tsx
@@ -124,7 +124,11 @@ export const SiteNav = ({ current, position = "fixed" }: SiteNavProps) => {
         </button>
       </div>
 
-      <div className={`mobileBottomNav ${gm500.className}`} aria-label="Mobile navigation">
+      <div
+        className={`mobileBottomNav ${gm500.className}`}
+        role="navigation"
+        aria-label="Mobile navigation"
+      >
         <Link href="/" className="mobileNavItem" aria-label="Home">
           <span className="mobileHomeLogo" aria-hidden>
             <svg viewBox="0 0 1500 1500" className="mobileHomeMark" aria-hidden>
@@ -337,7 +341,7 @@ export const SiteNav = ({ current, position = "fixed" }: SiteNavProps) => {
             --mobile-bottom-nav-h: 64px;
           }
           body {
-            padding-bottom: calc(var(--mobile-bottom-nav-h) + env(safe-area-inset-bottom));
+            padding-bottom: calc(var(--mobile-bottom-nav-h) + env(safe-area-inset-bottom, 0px));
           }
           .topnav {
             --nav-h: 0px;
@@ -360,8 +364,8 @@ export const SiteNav = ({ current, position = "fixed" }: SiteNavProps) => {
             z-index: 60;
             display: grid;
             grid-template-columns: repeat(5, minmax(0, 1fr));
-            min-height: calc(var(--mobile-bottom-nav-h) + env(safe-area-inset-bottom));
-            padding: 7px clamp(10px, 3vw, 16px) calc(7px + env(safe-area-inset-bottom));
+            min-height: calc(var(--mobile-bottom-nav-h) + env(safe-area-inset-bottom, 0px));
+            padding: 7px clamp(10px, 3vw, 16px) calc(7px + env(safe-area-inset-bottom, 0px));
             background: color-mix(in srgb, var(--paper) 94%, transparent);
             border-top: 1px solid var(--rule);
             backdrop-filter: blur(14px);

--- a/components/lab/Notebook.tsx
+++ b/components/lab/Notebook.tsx
@@ -56,6 +56,7 @@ interface EssayLike extends BaseEntry {
   read?: string;
   image?: string;
   imageAlt?: string;
+  imageAspectRatio?: string;
 }
 
 interface NoteEntry extends BaseEntry {
@@ -70,6 +71,7 @@ interface PhotoEntry extends BaseEntry {
   fig: string;
   image?: string;
   imageAlt?: string;
+  imageAspectRatio?: string;
   swatches?: string[];
 }
 
@@ -601,51 +603,112 @@ const Notebook = ({
   // Next's client router can remount the homepage without the browser doing
   // native scroll restoration. When a card opens an article, store the card's
   // viewport offset and nudge it back to that same spot after the homepage
-  // remounts. Repeating for a few frames handles image-driven layout shifts.
+  // remounts. A short, throttled retry window handles hash-scroll and image
+  // layout shifts without fighting the user for multiple seconds.
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const raw = window.sessionStorage.getItem(NOTEBOOK_RETURN_SCROLL_KEY);
-    if (!raw) return;
-
-    let snapshot: NotebookReturnScrollSnapshot;
-    try {
-      snapshot = JSON.parse(raw) as NotebookReturnScrollSnapshot;
-    } catch {
-      return;
-    }
-
-    if (!Number.isFinite(snapshot.scrollY) || Date.now() - snapshot.ts > 5 * 60 * 1000) {
-      return;
-    }
-
-    let frame = 0;
-    let raf = 0;
-    const restore = () => {
-      const target = snapshot.entryId
-        ? Array.from(document.querySelectorAll<HTMLElement>("[data-entry-id]")).find(
-            (node) => node.dataset.entryId === snapshot.entryId,
-          )
-        : null;
-
-      const entryTop = snapshot.entryTop;
-      if (target && typeof entryTop === "number" && Number.isFinite(entryTop)) {
-        const delta = target.getBoundingClientRect().top - entryTop;
-        window.scrollTo({ top: Math.max(0, window.scrollY + delta), behavior: "auto" });
-      } else {
-        window.scrollTo({ top: snapshot.scrollY, behavior: "auto" });
-      }
-
-      frame += 1;
-      if (frame < 120) {
-        raf = window.requestAnimationFrame(restore);
-      } else {
+    const clearSnapshot = () => {
+      try {
         window.sessionStorage.removeItem(NOTEBOOK_RETURN_SCROLL_KEY);
+      } catch {
+        // Storage can throw in private browsing; restoration is best-effort.
       }
     };
 
-    raf = window.requestAnimationFrame(restore);
-    return () => window.cancelAnimationFrame(raf);
+    const beginRestore = (): (() => void) | undefined => {
+      let raw: string | null = null;
+      try {
+        raw = window.sessionStorage.getItem(NOTEBOOK_RETURN_SCROLL_KEY);
+      } catch {
+        return undefined;
+      }
+      if (!raw) return undefined;
+
+      let snapshot: NotebookReturnScrollSnapshot;
+      try {
+        snapshot = JSON.parse(raw) as NotebookReturnScrollSnapshot;
+      } catch {
+        clearSnapshot();
+        return undefined;
+      }
+
+      if (!Number.isFinite(snapshot.scrollY) || Date.now() - snapshot.ts > 5 * 60 * 1000) {
+        clearSnapshot();
+        return undefined;
+      }
+
+      const entryTop = snapshot.entryTop;
+      const entrySelector = snapshot.entryId?.match(/^[a-z0-9-]+$/)
+        ? `[data-entry-id="${snapshot.entryId}"]`
+        : null;
+      let target = entrySelector ? document.querySelector<HTMLElement>(entrySelector) : null;
+      let attempt = 0;
+      let stableCount = 0;
+      let timeout = 0;
+      let aborted = false;
+
+      const cleanup = () => {
+        window.clearTimeout(timeout);
+        window.removeEventListener("pointerdown", abort);
+        window.removeEventListener("touchstart", abort);
+        window.removeEventListener("wheel", abort);
+        window.removeEventListener("keydown", abort);
+      };
+
+      const abort = () => {
+        aborted = true;
+        clearSnapshot();
+        cleanup();
+      };
+
+      const restore = () => {
+        if (aborted) return;
+        if (!target && entrySelector) target = document.querySelector<HTMLElement>(entrySelector);
+
+        let shouldStop = false;
+        if (target && typeof entryTop === "number" && Number.isFinite(entryTop)) {
+          const delta = target.getBoundingClientRect().top - entryTop;
+          if (Math.abs(delta) < 1) {
+            stableCount += 1;
+            shouldStop = stableCount >= 4 && attempt >= 6;
+          } else {
+            stableCount = 0;
+            window.scrollTo({ top: Math.max(0, window.scrollY + delta), behavior: "auto" });
+          }
+        } else {
+          window.scrollTo({ top: snapshot.scrollY, behavior: "auto" });
+          shouldStop = true;
+        }
+
+        attempt += 1;
+        if (attempt < 30 && !shouldStop) {
+          timeout = window.setTimeout(restore, 50);
+        } else {
+          clearSnapshot();
+          cleanup();
+        }
+      };
+
+      window.addEventListener("pointerdown", abort, { once: true });
+      window.addEventListener("touchstart", abort, { once: true });
+      window.addEventListener("wheel", abort, { once: true });
+      window.addEventListener("keydown", abort, { once: true });
+      timeout = window.setTimeout(restore, 0);
+      return cleanup;
+    };
+
+    let cleanupRestore = beginRestore();
+    const handlePageShow = () => {
+      cleanupRestore?.();
+      cleanupRestore = beginRestore();
+    };
+    window.addEventListener("pageshow", handlePageShow);
+
+    return () => {
+      cleanupRestore?.();
+      window.removeEventListener("pageshow", handlePageShow);
+    };
   }, []);
 
   // Toggle a `.is-stuck` class on the chip bar once it actually sticks to
@@ -1132,7 +1195,11 @@ const EntryCard = ({
       scrollY: window.scrollY,
       ts: Date.now(),
     };
-    window.sessionStorage.setItem(NOTEBOOK_RETURN_SCROLL_KEY, JSON.stringify(snapshot));
+    try {
+      window.sessionStorage.setItem(NOTEBOOK_RETURN_SCROLL_KEY, JSON.stringify(snapshot));
+    } catch {
+      // Storage can throw in private browsing; navigation should still proceed.
+    }
   };
   const cardStyle: React.CSSProperties = {
     background: tint,
@@ -1349,6 +1416,11 @@ interface EntryBodyProps {
   italicSerifClass: string;
 }
 
+const imageAspectStyle = (imageAspectRatio?: string): React.CSSProperties | undefined =>
+  imageAspectRatio
+    ? ({ ["--card-image-aspect" as string]: imageAspectRatio } as React.CSSProperties)
+    : undefined;
+
 const EntryBody = ({ entry, monoClass, serifClass, italicSerifClass }: EntryBodyProps) => {
   switch (entry.type) {
     case "essay":
@@ -1358,7 +1430,12 @@ const EntryBody = ({ entry, monoClass, serifClass, italicSerifClass }: EntryBody
       return (
         <>
           {entry.image ? (
-            <img className="cardCoverImage" src={entry.image} alt={entry.imageAlt ?? ""} />
+            <img
+              className="cardCoverImage"
+              src={entry.image}
+              alt={entry.imageAlt ?? ""}
+              style={imageAspectStyle(entry.imageAspectRatio)}
+            />
           ) : null}
           <h3 className={`title ${monoClass}`}>
             {entry.accent ? (
@@ -1390,7 +1467,12 @@ const EntryBody = ({ entry, monoClass, serifClass, italicSerifClass }: EntryBody
       return (
         <>
           {entry.image ? (
-            <img className="photoPreview" src={entry.image} alt={entry.imageAlt ?? entry.caption} />
+            <img
+              className="photoPreview"
+              src={entry.image}
+              alt={entry.imageAlt ?? entry.caption}
+              style={imageAspectStyle(entry.imageAspectRatio)}
+            />
           ) : (
             <div className="photoStrip" aria-hidden>
               {(entry.swatches ?? ["#c8b89a", "#9ba78c", "#5a4a3a"]).map((s, i) => (
@@ -1612,7 +1694,7 @@ const Body = () => (
       :global(.cardCoverImage),
       :global(.photoPreview) {
         height: auto;
-        aspect-ratio: auto;
+        aspect-ratio: auto var(--card-image-aspect, 16 / 9);
         object-fit: contain;
       }
     }

--- a/lib/vault/to-notebook.ts
+++ b/lib/vault/to-notebook.ts
@@ -7,8 +7,9 @@
  * vault without any client-side fetching.
  *
  * Grouping: notes are bucketed by `YYYY-MM` from frontmatter.date. Each
- * month renders as one dense three-column grid so authored `preview.span`
- * can create wider/taller feature cards instead of the old equal-card wall.
+ * month renders as dense three-column grid rows so authored `preview.span`
+ * can create wider/taller feature cards while the month label keeps a sticky
+ * scroll range on desktop.
  *
  * Entry type derivation is content-type aware:
  *   writing → article card, with optional `preview.image` cover
@@ -65,6 +66,13 @@ const bannerImage = (fm: VaultNote["frontmatter"]): string | undefined => {
   return stringField(banner.light) ?? stringField(banner.dark);
 };
 
+const knownImageAspectRatio = (image: string | undefined): string | undefined => {
+  if (!image) return undefined;
+  if (/\/img\/photos\/[^/]*banner\.(png|jpe?g|webp)$/i.test(image)) return "1024 / 400";
+  if (image.startsWith("/vault-assets/")) return "1376 / 768";
+  return undefined;
+};
+
 const noteKindToEntryType = (kind: PreviewKind | undefined): EntryType => {
   switch (kind) {
     case "image":
@@ -113,6 +121,7 @@ const noteToEntry = (note: VaultNote, index: number): Entry => {
   const headline = preview.headline ?? fm.title;
   const excerpt = preview.excerpt ?? "";
   const image = preview.image ?? bannerImage(fm);
+  const imageAspectRatio = knownImageAspectRatio(image);
 
   const base = {
     id: note.slug,
@@ -129,7 +138,9 @@ const noteToEntry = (note: VaultNote, index: number): Entry => {
       title: headline,
       caption: excerpt || headline,
       fig: `FIG.${index.toString().padStart(2, "0")}`,
-      ...(image !== undefined ? { image, imageAlt: headline } : {}),
+      ...(image !== undefined
+        ? { image, imageAlt: headline, ...(imageAspectRatio ? { imageAspectRatio } : {}) }
+        : {}),
     };
   }
   if (type === "quote") {
@@ -151,7 +162,9 @@ const noteToEntry = (note: VaultNote, index: number): Entry => {
     title: headline,
     blurb: excerpt,
     read: computeReadTime(note.bodyMarkdown),
-    ...(image !== undefined ? { image, imageAlt: headline } : {}),
+    ...(image !== undefined
+      ? { image, imageAlt: headline, ...(imageAspectRatio ? { imageAspectRatio } : {}) }
+      : {}),
   };
 };
 
@@ -169,6 +182,16 @@ const rowSpanForNote = (note: VaultNote): number | undefined => {
     return 2;
   }
   return undefined;
+};
+
+const rowsForCells = (cells: NotebookCell[]): NotebookRow[] => {
+  if (cells.length > 1) {
+    return [
+      { cols: DEFAULT_COLS, cells: cells.slice(0, -1) },
+      { cols: DEFAULT_COLS, cells: cells.slice(-1) },
+    ];
+  }
+  return [{ cols: DEFAULT_COLS, cells }];
 };
 
 const cellForNote = (note: VaultNote, index: number): NotebookCell => {
@@ -228,7 +251,7 @@ export function notesToNotebookMonths(notes: VaultNote[]): NotebookMonth[] {
     const cells: NotebookCell[] = items.map((n) =>
       cellForNote(n, indexBySlug.get(n.slug) ?? 0),
     );
-    const rows: NotebookRow[] = [{ cols: DEFAULT_COLS, cells }];
+    const rows = rowsForCells(cells);
 
     return {
       key,


### PR DESCRIPTION
## Summary
- removes the redundant mobile topbar and uses the DY mark for the bottom-nav home icon
- collapses the mobile work grid/cards cleanly, preserves intrinsic image ratios, and adds return-scroll restoration after opening articles
- tightens the mobile landing hero and contact/weather layout: centered/larger hero, side-by-side date/weather widgets, and aspect-ratio-safe contact image card

## Test Plan
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run test:run
- [x] npm run build
- [x] Playwright mobile smoke for hero, work cards, contact widgets, and browser-back scroll restoration

## Notes
This is stacked onto #59 / `checkpoint/about-page-current-state` as the cleanup pass from the live mobile review thread.
