### PR TITLE
fix: polish responsive article tables

### DIFF
--- a/lib/vault/render.ts
+++ b/lib/vault/render.ts
@@ -47,6 +47,61 @@ export type { WikilinkResolveOpts } from "./wikilinks";
 const HEADING_TAGS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
 
 /**
+ * Wrap markdown tables after sanitization so article pages can style them as
+ * scrollable frames without requiring markdown authors to write raw HTML.
+ */
+const rehypeArticleTableFrames: Plugin<[], Root> = function () {
+  return (tree: Root) => {
+    wrapTables(tree);
+  };
+};
+
+function wrapTables(node: Root | Element): void {
+  if (!("children" in node)) return;
+
+  node.children = node.children.map((child) => {
+    if (child.type !== "element") {
+      return child;
+    }
+
+    if (child.tagName === "table") {
+      child.properties = {
+        ...child.properties,
+        className: mergeClassName(child.properties?.className, "articleTable"),
+      };
+
+      return {
+        type: "element",
+        tagName: "div",
+        properties: {
+          className: ["articleTableFrame"],
+          role: "region",
+          "aria-label": "Scrollable table",
+          tabIndex: 0,
+        },
+        children: [child],
+      };
+    }
+
+    wrapTables(child);
+    return child;
+  });
+}
+
+function mergeClassName(
+  className: Element["properties"]["className"],
+  nextClassName: string,
+): string[] {
+  const classes = Array.isArray(className)
+    ? className.map(String)
+    : typeof className === "string"
+      ? className.split(/\s+/).filter(Boolean)
+      : [];
+
+  return classes.includes(nextClassName) ? classes : [...classes, nextClassName];
+}
+
+/**
  * Wrap heading contents in an inline span after sanitization. Article pages
  * use this child span for multiline highlighter backgrounds with
  * `box-decoration-break: clone`; applying the class here keeps markdown
@@ -110,6 +165,7 @@ const stripProcessor = unified()
   .use(remarkRehype, { allowDangerousHtml: true })
   .use(rehypeRaw)
   .use(rehypeSanitize)
+  .use(rehypeArticleTableFrames)
   .use(rehypeArticleHeadingSpans)
   .use(rehypeStringify)
   .freeze();
@@ -144,6 +200,7 @@ export async function renderMarkdown(
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)
     .use(rehypeSanitize)
+    .use(rehypeArticleTableFrames)
     .use(rehypeArticleHeadingSpans)
     .use(rehypeStringify);
 

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -387,6 +387,107 @@ export default function WorkSlug({ note }: Props) {
           background: transparent;
           border: 0;
         }
+        .articleBody .articleTableFrame {
+          position: relative;
+          max-width: 100%;
+          margin: 32px 0;
+          overflow-x: auto;
+          -webkit-overflow-scrolling: touch;
+          background:
+            linear-gradient(90deg, var(--paper-2) 30%, rgba(255, 255, 255, 0)),
+            linear-gradient(90deg, rgba(255, 255, 255, 0), var(--paper-2) 70%) 100% 0,
+            linear-gradient(90deg, var(--accent-soft), rgba(255, 255, 255, 0)),
+            linear-gradient(270deg, var(--accent-soft), rgba(255, 255, 255, 0)) 100% 0,
+            var(--paper-2);
+          background-attachment: local, local, scroll, scroll;
+          background-repeat: no-repeat;
+          background-size: 36px 100%, 36px 100%, 18px 100%, 18px 100%;
+          border: 1px solid var(--rule);
+          border-radius: 6px;
+          box-shadow: 0 14px 38px rgba(22, 20, 14, 0.08);
+        }
+        .articleBody .articleTableFrame:focus-visible {
+          outline: 2px solid var(--accent);
+          outline-offset: 3px;
+        }
+        [data-theme="dark"] .articleBody .articleTableFrame {
+          box-shadow: 0 16px 42px rgba(0, 0, 0, 0.34);
+        }
+        .articleBody .articleTableFrame::-webkit-scrollbar {
+          height: 10px;
+        }
+        .articleBody .articleTableFrame::-webkit-scrollbar-track {
+          background: transparent;
+        }
+        .articleBody .articleTableFrame::-webkit-scrollbar-thumb {
+          background: var(--rule);
+          border: 3px solid var(--paper-2);
+          border-radius: 999px;
+        }
+        .articleBody .articleTable {
+          width: max-content;
+          min-width: 100%;
+          border-collapse: separate;
+          border-spacing: 0;
+          color: var(--ink);
+          font-size: 0.86em;
+          line-height: 1.45;
+        }
+        .articleBody .articleTable thead {
+          background: var(--accent-soft);
+        }
+        .articleBody .articleTable th,
+        .articleBody .articleTable td {
+          min-width: 9rem;
+          max-width: 24rem;
+          padding: 12px 16px;
+          border-right: 1px solid var(--rule);
+          border-bottom: 1px solid var(--rule);
+          text-align: left;
+          vertical-align: top;
+          overflow-wrap: anywhere;
+        }
+        .articleBody .articleTable th:last-child,
+        .articleBody .articleTable td:last-child {
+          border-right: 0;
+        }
+        .articleBody .articleTable tr:last-child td {
+          border-bottom: 0;
+        }
+        .articleBody .articleTable th {
+          font-family:
+            "Geist Mono",
+            ui-monospace,
+            monospace;
+          font-size: 0.78em;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          color: var(--ink);
+        }
+        .articleBody .articleTable tbody tr:nth-child(even) {
+          background: color-mix(in srgb, var(--accent-soft) 38%, transparent);
+        }
+        .articleBody .articleTable code,
+        .articleBody .articleTable a {
+          overflow-wrap: anywhere;
+        }
+        @supports not (background: color-mix(in srgb, black 50%, white)) {
+          .articleBody .articleTable tbody tr:nth-child(even) {
+            background: var(--accent-soft);
+          }
+        }
+        @media (max-width: 640px) {
+          .articleBody .articleTableFrame {
+            margin-left: -4px;
+            margin-right: -4px;
+            border-radius: 4px;
+          }
+          .articleBody .articleTable th,
+          .articleBody .articleTable td {
+            min-width: 10.5rem;
+            padding: 11px 14px;
+          }
+        }
         .articleBody blockquote {
           margin: 24px 0;
           padding: 4px 0 4px 20px;

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -393,11 +393,13 @@ export default function WorkSlug({ note }: Props) {
           margin: 32px 0;
           overflow-x: auto;
           -webkit-overflow-scrolling: touch;
+          scrollbar-width: thin;
+          scrollbar-color: var(--rule) transparent;
           background:
-            linear-gradient(90deg, var(--paper-2) 30%, rgba(255, 255, 255, 0)),
-            linear-gradient(90deg, rgba(255, 255, 255, 0), var(--paper-2) 70%) 100% 0,
-            linear-gradient(90deg, var(--accent-soft), rgba(255, 255, 255, 0)),
-            linear-gradient(270deg, var(--accent-soft), rgba(255, 255, 255, 0)) 100% 0,
+            linear-gradient(90deg, var(--paper-2) 30%, transparent),
+            linear-gradient(90deg, transparent, var(--paper-2) 70%) 100% 0,
+            linear-gradient(90deg, var(--accent-soft), transparent),
+            linear-gradient(270deg, var(--accent-soft), transparent) 100% 0,
             var(--paper-2);
           background-attachment: local, local, scroll, scroll;
           background-repeat: no-repeat;

--- a/test/vault/render.test.ts
+++ b/test/vault/render.test.ts
@@ -55,10 +55,13 @@ describe("renderMarkdown", () => {
     expect(html).toContain("<li>");
   });
 
-  it("renders GFM tables", async () => {
+  it("renders GFM tables inside the article table frame", async () => {
     const md = `| A | B |\n| - | - |\n| 1 | 2 |`;
     const html = await renderMarkdown(md);
-    expect(html).toContain("<table>");
+    expect(html).toContain(
+      '<div class="articleTableFrame" role="region" aria-label="Scrollable table" tabindex="0">',
+    );
+    expect(html).toContain('<table class="articleTable">');
     expect(html).toContain("<th>");
     expect(html).toContain("<td>");
   });


### PR DESCRIPTION
## Summary
- Wrap sanitized markdown tables in an articleTableFrame scroll region during vault rendering
- Style article tables with a framed/card treatment, theme-aware borders/backgrounds, header tint, cell padding, separators, and mobile-safe horizontal scrolling
- Cover the renderer wrapper/class contract in renderMarkdown tests

## Verification
- npm run test:run -- test/vault/render.test.ts
- npm run check
- Local smoke: VAULT_SOURCE=local VAULT_PATH=/tmp/ika-table-vault npm run dev -- --hostname 127.0.0.1 --port 4321, checked /blog/table-post in browser; desktop frame scrollWidth 984 > clientWidth 694 with overflow-x:auto; mobile screenshot at 390x900 showed readable columns and visible horizontal scrollbar; dark mode computed frame uses dark paper/rule vars.

## Notes
- Requested local base fix/shared-blog-work-cards resolves to fce90dd, which is also origin/develop; the named base branch is not present on origin, so this PR targets develop.
- npm ci was needed because this worktree did not have local node_modules before testing.