### PR TITLE
feat: hide blog for homepage release candidate

### DIFF
--- a/components/SiteNav.tsx
+++ b/components/SiteNav.tsx
@@ -17,7 +17,7 @@ import { BookOpen, BriefcaseBusiness, FileText, Mail, Moon, Sun } from "lucide-r
 
 import Context from "./context";
 import { gm500, gm800 } from "../global/fonts";
-import { ABOUT_PAGE_ENABLED } from "../lib/flags";
+import { ABOUT_PAGE_ENABLED, BLOG_PAGE_ENABLED } from "../lib/flags";
 
 const DY_PATHS: readonly string[] = [
   "M 1371.48 700.4 L 1371.67 1013.54 L 1371.67 1063.38 C 1371.67 1238.53 1229.69 1380.51 1054.54 1380.51 L 990.63 1380.51",
@@ -73,13 +73,15 @@ export const SiteNav = ({ current, position = "fixed" }: SiteNavProps) => {
           >
             <span className="navTabLabel">Work</span>
           </Link>
-          <Link
-            className={`navTab tabAbout ${gm500.className}`}
-            href="/blog"
-            data-current={current === "blog" ? "true" : undefined}
-          >
-            <span className="navTabLabel">Blog</span>
-          </Link>
+          {BLOG_PAGE_ENABLED ? (
+            <Link
+              className={`navTab tabAbout ${gm500.className}`}
+              href="/blog"
+              data-current={current === "blog" ? "true" : undefined}
+            >
+              <span className="navTabLabel">Blog</span>
+            </Link>
+          ) : null}
           {ABOUT_PAGE_ENABLED ? (
             <Link
               className={`navTab tabAbout ${gm500.className}`}
@@ -135,6 +137,9 @@ export const SiteNav = ({ current, position = "fixed" }: SiteNavProps) => {
         className={`mobileBottomNav ${gm500.className}`}
         role="navigation"
         aria-label="Mobile navigation"
+        style={{
+          gridTemplateColumns: `repeat(${BLOG_PAGE_ENABLED ? 6 : 5}, minmax(0, 1fr))`,
+        }}
       >
         <Link href="/" className="mobileNavItem" aria-label="Home">
           <span className="mobileHomeLogo" aria-hidden>
@@ -173,15 +178,17 @@ export const SiteNav = ({ current, position = "fixed" }: SiteNavProps) => {
           <BriefcaseBusiness className="mobileNavIcon" aria-hidden />
           <span>Work</span>
         </Link>
-        <Link
-          href="/blog"
-          className="mobileNavItem"
-          data-current={current === "blog" ? "true" : undefined}
-          aria-label="Blog"
-        >
-          <BookOpen className="mobileNavIcon" aria-hidden />
-          <span>Blog</span>
-        </Link>
+        {BLOG_PAGE_ENABLED ? (
+          <Link
+            href="/blog"
+            className="mobileNavItem"
+            data-current={current === "blog" ? "true" : undefined}
+            aria-label="Blog"
+          >
+            <BookOpen className="mobileNavIcon" aria-hidden />
+            <span>Blog</span>
+          </Link>
+        ) : null}
         <Link
           href="/#footer"
           className="mobileNavItem"
@@ -381,7 +388,6 @@ export const SiteNav = ({ current, position = "fixed" }: SiteNavProps) => {
             bottom: 0;
             z-index: 60;
             display: grid;
-            grid-template-columns: repeat(6, minmax(0, 1fr));
             min-height: calc(var(--mobile-bottom-nav-h) + env(safe-area-inset-bottom, 0px));
             padding: 7px clamp(10px, 3vw, 16px) calc(7px + env(safe-area-inset-bottom, 0px));
             background: color-mix(in srgb, var(--paper) 94%, transparent);

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,5 +1,5 @@
 /**
- * lib/flags.ts — runtime feature flags.
+ * lib/flags.ts — compile-time feature flags.
  *
  * Single source of truth for in-progress features that aren't ready to ship.
  * Each flag is a plain boolean constant — flipping requires a commit + deploy,
@@ -22,3 +22,17 @@
  *   - `components/SiteNav.tsx` omits the About tab from the nav row.
  */
 export const ABOUT_PAGE_ENABLED = false;
+
+/**
+ * `/blog` index + article pages + navigation links.
+ *
+ * Disabled for the release candidate while the public articles receive their
+ * final editorial pass. Flip to `true` once the blog is ready to ship.
+ *
+ * When `false`:
+ *   - `pages/blog/index.tsx` returns `notFound` before reading the vault.
+ *   - `pages/blog/[slug].tsx` generates no paths and returns `notFound`
+ *     before reading the vault or requested slug.
+ *   - `components/SiteNav.tsx` omits Blog from desktop and mobile navigation.
+ */
+export const BLOG_PAGE_ENABLED = false;

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -18,6 +18,7 @@ import type { VaultNote } from "../../lib/vault/schema";
 import SiteNav from "../../components/SiteNav";
 import { getPublicNotes, getNoteBySlug } from "../../lib/vault";
 import Context from "../../components/context";
+import { BLOG_PAGE_ENABLED } from "../../lib/flags";
 import { themeBootstrap } from "../../lib/theme-bootstrap";
 import { gm500, gm800, cp400 } from "../../global/fonts";
 import { dotGridColor } from "../../lib/dot-grid-color";
@@ -56,6 +57,10 @@ interface Props {
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
+  if (!BLOG_PAGE_ENABLED) {
+    return { paths: [], fallback: false };
+  }
+
   const notes = await getPublicNotes();
   return {
     paths: notes.map((n) => ({ params: { slug: n.slug } })),
@@ -65,8 +70,12 @@ export const getStaticPaths: GetStaticPaths = async () => {
   };
 };
 
-export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
-  const slug = params?.slug as string;
+export const getStaticProps: GetStaticProps<Props> = async (context) => {
+  if (!BLOG_PAGE_ENABLED) {
+    return { notFound: true };
+  }
+
+  const slug = context.params?.slug as string;
   const note = await getNoteBySlug(slug);
 
   if (!note) {

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -9,6 +9,7 @@ import { HiSpan } from "../../components/Highlighter";
 import type { Entry, NotebookMonth } from "../../components/lab/Notebook";
 import { gm500, gm800, cp400, cp400i } from "../../global/fonts";
 import { dotGridColor } from "../../lib/dot-grid-color";
+import { BLOG_PAGE_ENABLED } from "../../lib/flags";
 import { themeBootstrap } from "../../lib/theme-bootstrap";
 import { getPublicNotes, getVaultConfig, getVaultTaxonomy } from "../../lib/vault";
 import { notesToNotebookMonths } from "../../lib/vault/to-notebook";
@@ -32,6 +33,10 @@ const BLOG_LEDE =
   "Notes, half-formed arguments, build logs, and the occasional coherent thought. Basically where the rambling goes once it seems useful enough to leave in public.";
 
 export const getStaticProps: GetStaticProps<BlogIndexProps> = async () => {
+  if (!BLOG_PAGE_ENABLED) {
+    return { notFound: true };
+  }
+
   const [notes, taxonomy] = await Promise.all([getPublicNotes(), getVaultTaxonomy()]);
   const surfaced = notes.filter(
     (note) => note.frontmatter.type === "work" || note.frontmatter.type === "writing",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -722,9 +722,11 @@ const Index = ({ workProjects, weather }: IndexProps) => {
               <HiSpan slot={2}>WORK</HiSpan>
             </h2>
             <p className={`historyLede ${cp400.className}`}>
-              A curated set of live projects and public repos I actually want people
-              to see. Deployed work floats first, then the rest follows recent
-              authored GitHub activity when the daily cache can check it.
+              Here are a few things I&apos;ve enjoyed building. You can find more of my work on{" "}
+              <a href="https://github.com/donovan-yohan" target="_blank" rel="noreferrer">
+                GitHub
+              </a>
+              .
             </p>
           </header>
 
@@ -909,6 +911,14 @@ const Index = ({ workProjects, weather }: IndexProps) => {
           font-size: clamp(18px, 1.6vw, 22px);
           line-height: 1.45;
           color: var(--ink-soft);
+        }
+        .historyLede a {
+          color: inherit;
+          text-decoration-thickness: 1px;
+          text-underline-offset: 0.18em;
+        }
+        .historyLede a:hover {
+          color: var(--ink);
         }
 
         /* Contact / footer — tabloid sketchbook layout. Cards float in

--- a/test/blog-feature-flag.test.ts
+++ b/test/blog-feature-flag.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+
+import type { GetStaticPathsContext, GetStaticPropsContext } from "next";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const vaultMocks = vi.hoisted(() => ({
+  getNoteBySlug: vi.fn(),
+  getPublicNotes: vi.fn(),
+  getVaultConfig: vi.fn(),
+  getVaultTaxonomy: vi.fn(),
+}));
+
+vi.mock("../lib/vault", () => vaultMocks);
+vi.mock("next/font/google", () => ({
+  Geist_Mono: () => ({ className: "geist-mono" }),
+  Crimson_Pro: () => ({ className: "crimson-pro" }),
+  Caveat: () => ({ className: "caveat" }),
+}));
+
+import { BLOG_PAGE_ENABLED } from "../lib/flags";
+import { getStaticProps as getBlogIndexStaticProps } from "../pages/blog";
+import {
+  getStaticPaths as getBlogSlugStaticPaths,
+  getStaticProps as getBlogSlugStaticProps,
+} from "../pages/blog/[slug]";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("disabled blog feature flag", () => {
+  test("defaults to false", () => {
+    expect(BLOG_PAGE_ENABLED).toBe(false);
+  });
+
+  test("/blog returns notFound before any vault reads", async () => {
+    const result = await getBlogIndexStaticProps({} as GetStaticPropsContext);
+
+    expect(result).toEqual({ notFound: true });
+    expect(vaultMocks.getPublicNotes).not.toHaveBeenCalled();
+    expect(vaultMocks.getVaultTaxonomy).not.toHaveBeenCalled();
+    expect(vaultMocks.getVaultConfig).not.toHaveBeenCalled();
+  });
+
+  test("/blog/[slug] generates no paths without reading the vault", async () => {
+    const result = await getBlogSlugStaticPaths({} as GetStaticPathsContext);
+
+    expect(result).toEqual({ paths: [], fallback: false });
+    expect(vaultMocks.getPublicNotes).not.toHaveBeenCalled();
+  });
+
+  test("/blog/[slug] returns notFound before reading params or the vault", async () => {
+    const context = Object.defineProperty({}, "params", {
+      get: () => {
+        throw new Error("disabled blog route read params");
+      },
+    }) as GetStaticPropsContext;
+
+    const result = await getBlogSlugStaticProps(context);
+
+    expect(result).toEqual({ notFound: true });
+    expect(vaultMocks.getNoteBySlug).not.toHaveBeenCalled();
+  });
+});

--- a/test/site-nav.test.tsx
+++ b/test/site-nav.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
 vi.mock("next/font/google", () => ({
@@ -11,6 +11,35 @@ import Context from "../components/context";
 import SiteNav from "../components/SiteNav";
 
 describe("SiteNav", () => {
+  test("omits Blog from desktop and mobile navigation without leaving an empty column", () => {
+    const { container } = render(
+      <Context.Provider value={{ theme: "light", toggleTheme: vi.fn() }}>
+        <SiteNav current="work" />
+      </Context.Provider>,
+    );
+
+    const desktopNav = container.querySelector(".navTabs");
+    expect(desktopNav).not.toBeNull();
+    expect(within(desktopNav as HTMLElement).queryByRole("link", { name: "Blog" })).toBeNull();
+
+    const mobileNav = container.querySelector('[aria-label="Mobile navigation"]');
+    expect(mobileNav).not.toBeNull();
+    expect((mobileNav as HTMLElement).querySelector('a[href="/blog"]')).toBeNull();
+    expect((mobileNav as HTMLElement).querySelectorAll(".mobileNavItem")).toHaveLength(5);
+    expect(mobileNav as HTMLElement).toHaveStyle({
+      gridTemplateColumns: "repeat(5, minmax(0, 1fr))",
+    });
+
+    expect(within(desktopNav as HTMLElement).getByRole("link", { name: "Work" })).toHaveAttribute(
+      "href",
+      "/#work",
+    );
+    expect((mobileNav as HTMLElement).querySelector('a[aria-label="Work"]')).toHaveAttribute(
+      "href",
+      "/#work",
+    );
+  });
+
   test("renders a stable circular theme-toggle control", async () => {
     const toggleTheme = vi.fn();
     render(


### PR DESCRIPTION
## Summary

Stacks onto the `develop` staging branch in #63.

Adds a default-off, compile-time `BLOG_PAGE_ENABLED` flag so the homepage design-system release candidate can ship while blog content is still being curated.

- hides Blog from desktop and mobile navigation
- keeps the mobile nav at five equal columns when Blog is disabled
- makes `/blog` and `/blog/[slug]` return real 404s before vault or slug access
- replaces the explanatory WORK intro with friendly copy and a direct GitHub profile link
- leaves `/work` and vault privacy behavior unchanged

## Verification

- `npm ci`
- `npm run test:run -- test/site-nav.test.tsx test/blog-feature-flag.test.ts` — 7/7 passed
- `npm run check` — passed (lint, typecheck, tests, build, leak test)
- `git diff --check`
- production server smoke:
  - `/` → 200, no Blog anchors, Work anchors present
  - WORK intro renders “Here are a few things I’ve enjoyed building.”
  - WORK intro links `GitHub` to `https://github.com/donovan-yohan`
  - `/blog` → 404
  - `/blog/not-a-real-post` → 404
  - `/work` → 200, no Blog anchors, Work anchors present
- Vercel exact-head preview: [open preview](https://donovanyohan-git-codex-flag-hide-3114f9-donovan-yohans-projects.vercel.app)
  - `/` → 200, no Blog anchors, Work anchors present
  - `/blog` → 404
  - `/blog/not-a-real-post` → 404
  - `/work` → 200, no Blog anchors, Work anchors present

## Agent evidence

- implementation: Codex CLI / OpenAI / `gpt-5.6-sol` / `xhigh`
- copy follow-up: direct edit from Kyle’s feedback; humanizer pass applied
- adversarial review: same Codex route; no unresolved P0/P1 findings
- `/simplify`: Codex CLI / OpenAI / `gpt-5.6-sol` / `high`; no worthwhile cleanup found, focused tests remained 7/7 green
