### PR TITLE
feat: finish article revisions and targeted preview renders

### DIFF
--- a/design/work-preview-cards/README.md
+++ b/design/work-preview-cards/README.md
@@ -16,4 +16,12 @@ node scripts/render-work-preview-cards.mjs
 PORTFOLIO_PREVIEW_URL=http://127.0.0.1:3113/ node scripts/capture-donovanyohan-hero-preview.mjs
 ```
 
+Render one generic card while iterating:
+
+```bash
+node scripts/render-work-preview-cards.mjs belayer
+```
+
+The portfolio's own preview still uses the separate live-hero capture command above.
+
 This needs the committed `playwright-core` devDependency plus a local Chromium binary (`chromium`, `chromium-browser`, `google-chrome`, or `CHROMIUM_BIN`).

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -93,6 +93,10 @@ export default function WorkSlug({ note }: Props) {
     typeof note.frontmatter.updated === "string" && note.frontmatter.updated !== note.frontmatter.date
       ? note.frontmatter.updated
       : null;
+  const changeNote =
+    updated && typeof note.frontmatter.changeNote === "string"
+      ? note.frontmatter.changeNote
+      : null;
   // Pull the article's accent slot off of preview so the h2 dot + title
   // underline pick up the right highlighter colour.
   const accentSlot = ((note.preview.accent || "yellow").toLowerCase().charCodeAt(0) % 4) + 1;
@@ -131,6 +135,12 @@ export default function WorkSlug({ note }: Props) {
 
         {note.preview.excerpt ? (
           <p className={`articleLede ${cp400.className}`}>{note.preview.excerpt}</p>
+        ) : null}
+
+        {changeNote ? (
+          <p className={`articleUpdateNote ${gm500.className}`}>
+            <span>Change note</span> {changeNote}
+          </p>
         ) : null}
 
         <hr className="articleRule" aria-hidden />
@@ -270,6 +280,22 @@ export default function WorkSlug({ note }: Props) {
           font-size: clamp(18px, 1.8vw, 22px);
           line-height: 1.5;
           color: var(--ink-soft);
+        }
+        .articleUpdateNote {
+          display: inline-block;
+          margin: 0 0 32px;
+          padding: 10px 12px;
+          border: 1px solid var(--rule);
+          background: var(--accent-soft);
+          font-size: 12px;
+          line-height: 1.5;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          color: var(--ink-soft);
+        }
+        .articleUpdateNote span {
+          margin-right: 8px;
+          color: var(--ink);
         }
         .articleRule {
           border: 0;

--- a/scripts/render-work-preview-cards.mjs
+++ b/scripts/render-work-preview-cards.mjs
@@ -9,25 +9,6 @@ const sourceHtml = resolve(repoRoot, "design/work-preview-cards/index.html");
 const renderedDir = resolve(process.env.TMPDIR ?? "/tmp", "donovanyohan-work-preview-cards");
 const publicDir = resolve(repoRoot, "public/img/work");
 
-const chromiumCandidates = [
-  process.env.CHROMIUM_BIN,
-  "chromium",
-  "chromium-browser",
-  "google-chrome",
-  "google-chrome-stable",
-].filter(Boolean);
-
-const chromium = chromiumCandidates.find((candidate) => {
-  const result = spawnSync("bash", ["-lc", `command -v ${candidate}`], { encoding: "utf8" });
-  return result.status === 0;
-});
-
-if (!chromium) {
-  throw new Error(
-    "No Chromium binary found. Set CHROMIUM_BIN or install chromium to render WORK preview screenshots."
-  );
-}
-
 const cards = [
   "relay-ide",
   "dynamic-workflows",
@@ -48,6 +29,25 @@ if (unknownCards.length > 0) {
   throw new Error(`Unknown WORK preview card slug(s): ${unknownCards.join(", ")}`);
 }
 const cardsToRender = selectedCards.length > 0 ? selectedCards : cards;
+
+const chromiumCandidates = [
+  process.env.CHROMIUM_BIN,
+  "chromium",
+  "chromium-browser",
+  "google-chrome",
+  "google-chrome-stable",
+].filter(Boolean);
+
+const chromium = chromiumCandidates.find((candidate) => {
+  const result = spawnSync("bash", ["-lc", `command -v ${candidate}`], { encoding: "utf8" });
+  return result.status === 0;
+});
+
+if (!chromium) {
+  throw new Error(
+    "No Chromium binary found. Set CHROMIUM_BIN or install chromium to render WORK preview screenshots."
+  );
+}
 
 mkdirSync(renderedDir, { recursive: true });
 mkdirSync(publicDir, { recursive: true });

--- a/scripts/render-work-preview-cards.mjs
+++ b/scripts/render-work-preview-cards.mjs
@@ -42,6 +42,13 @@ const cards = [
   "belayer",
 ];
 
+const selectedCards = process.argv.slice(2);
+const unknownCards = selectedCards.filter((slug) => !cards.includes(slug));
+if (unknownCards.length > 0) {
+  throw new Error(`Unknown WORK preview card slug(s): ${unknownCards.join(", ")}`);
+}
+const cardsToRender = selectedCards.length > 0 ? selectedCards : cards;
+
 mkdirSync(renderedDir, { recursive: true });
 mkdirSync(publicDir, { recursive: true });
 
@@ -68,7 +75,7 @@ const renderPng = (slug, theme) => {
   return output;
 };
 
-for (const slug of cards) {
+for (const slug of cardsToRender) {
   for (const theme of ["light", "dark"]) {
     const png = renderPng(slug, theme);
     const webp = resolve(publicDir, `${slug}-preview-${theme}.webp`);
@@ -82,4 +89,4 @@ for (const slug of cards) {
     .toFile(resolve(publicDir, `${slug}-preview.webp`));
 }
 
-console.log(`rendered ${cards.length} deterministic WORK preview cards using ${chromium}`);
+console.log(`rendered ${cardsToRender.length} deterministic WORK preview cards using ${chromium}`);

--- a/test/blog-article-revision.test.tsx
+++ b/test/blog-article-revision.test.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import type { VaultNote } from "../lib/vault/schema";
+
+vi.mock("next/dynamic", () => ({
+  default: () => () => null,
+}));
+vi.mock("next/head", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock("next/router", () => ({
+  useRouter: () => ({ pathname: "/blog/[slug]", asPath: "/blog/revised-article" }),
+}));
+vi.mock("../components/SiteNav", () => ({
+  default: () => null,
+}));
+vi.mock("../global/fonts", () => ({
+  gm500: { className: "gm500" },
+  gm800: { className: "gm800" },
+  cp400: { className: "cp400" },
+}));
+vi.mock("../lib/vault", () => ({
+  getNoteBySlug: vi.fn(),
+  getPublicNotes: vi.fn(),
+}));
+
+import BlogSlug from "../pages/blog/[slug]";
+
+const note = (updated: string, changeNote: string): VaultNote =>
+  ({
+    slug: "revised-article",
+    body: "<p>Body</p>",
+    preview: {
+      kind: "text",
+      excerpt: "Article summary",
+      accent: "yellow",
+    },
+    frontmatter: {
+      title: "Revised article",
+      date: "2026-05-10",
+      updated,
+      changeNote,
+      visibility: "public",
+      type: "writing",
+    },
+  }) as VaultNote;
+
+describe("blog article revision metadata", () => {
+  test("renders a change note only for a later revision date", () => {
+    const { rerender } = render(
+      <BlogSlug note={note("2026-06-04", "Clarified the memory-cost ladder.")} />
+    );
+
+    expect(screen.getByText("Updated JUN 4, 2026")).toBeInTheDocument();
+    expect(screen.getByText("Change note")).toBeInTheDocument();
+    expect(screen.getByText(/Clarified the memory-cost ladder/)).toBeInTheDocument();
+
+    rerender(<BlogSlug note={note("2026-05-10", "Should stay hidden.")} />);
+
+    expect(screen.queryByText(/Updated/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Change note")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Should stay hidden/)).not.toBeInTheDocument();
+  });
+});

--- a/test/blog-article-revision.test.tsx
+++ b/test/blog-article-revision.test.tsx
@@ -28,7 +28,7 @@ vi.mock("../lib/vault", () => ({
 
 import BlogSlug from "../pages/blog/[slug]";
 
-const note = (updated: string, changeNote: string): VaultNote =>
+const note = ({ updated, changeNote }: { updated?: string; changeNote?: string } = {}): VaultNote =>
   ({
     slug: "revised-article",
     body: "<p>Body</p>",
@@ -48,16 +48,38 @@ const note = (updated: string, changeNote: string): VaultNote =>
   }) as VaultNote;
 
 describe("blog article revision metadata", () => {
-  test("renders a change note only for a later revision date", () => {
+  test("renders a change note for a different revision date", () => {
     const { rerender } = render(
-      <BlogSlug note={note("2026-06-04", "Clarified the memory-cost ladder.")} />
+      <BlogSlug
+        note={note({
+          updated: "2026-06-04",
+          changeNote: "Clarified the memory-cost ladder.",
+        })}
+      />
     );
 
     expect(screen.getByText("Updated JUN 4, 2026")).toBeInTheDocument();
     expect(screen.getByText("Change note")).toBeInTheDocument();
     expect(screen.getByText(/Clarified the memory-cost ladder/)).toBeInTheDocument();
 
-    rerender(<BlogSlug note={note("2026-05-10", "Should stay hidden.")} />);
+    rerender(
+      <BlogSlug note={note({ updated: "2026-05-10", changeNote: "Should stay hidden." })} />
+    );
+
+    expect(screen.queryByText(/Updated/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Change note")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Should stay hidden/)).not.toBeInTheDocument();
+  });
+
+  test("renders an updated date without a change note", () => {
+    render(<BlogSlug note={note({ updated: "2026-06-04" })} />);
+
+    expect(screen.getByText("Updated JUN 4, 2026")).toBeInTheDocument();
+    expect(screen.queryByText("Change note")).not.toBeInTheDocument();
+  });
+
+  test("hides a change note when the revision date is missing", () => {
+    render(<BlogSlug note={note({ changeNote: "Should stay hidden." })} />);
 
     expect(screen.queryByText(/Updated/)).not.toBeInTheDocument();
     expect(screen.queryByText("Change note")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- render article revision change notes on `/blog/[slug]` only when `updated` differs from the publication date
- cover revised, same-date, missing-date, and updated-without-note behavior
- allow deterministic WORK preview rendering for selected slugs, validating arguments before Chromium discovery
- keep `donovanyohan` previews on the separate live-hero capture path

## Context

This selectively ports the surviving behavior from the local portfolio backlog onto current `develop`. The old checkpoint commits were not replayed directly because their route, card-grid, shell, cache-key, and binary-preview assumptions are stale or superseded by the current shared `PortfolioCardGrid`, ultrawide shell, and real-hero capture architecture.

## Validation

- `npm run check`
  - lint: 0 errors (11 pre-existing warnings)
  - typecheck: pass
  - tests: 29 files / 354 tests pass
  - production build: pass
  - leak test: 14 tests pass
- targeted revision + fail-closed tests: 28 pass
- targeted `belayer` preview render: pass with no asset drift
- unknown-slug validation: pass even with `CHROMIUM_BIN` pointed at a missing binary
- browser smoke: 1440px desktop and 390px mobile, light/dark, no horizontal overflow
- opposing-family review: Claude Opus 5 (high), no blockers; actionable coverage and argument-order findings applied
- `/simplify`: reuse/altitude/efficiency lanes found no worthwhile in-scope cleanup beyond the applied validation ordering and test cleanup
