### PR TITLE
test: isolate leak-check build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # next.js
 /.next/
+/.next-leak-test/
 /tsconfig.tsbuildinfo
 /out/
 /public/vault-assets/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 node_modules
 .next
+.next-leak-test
 out
 coverage
 package-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ This is Donovan Yohan's portfolio site. It uses Next.js Pages Router, React, sty
 
 - Keep visual behavior stable unless the task is explicitly a redesign.
 - Use the existing Pages Router and component structure.
-- Keep generated folders (`.next`, `out`, `coverage`, `node_modules`) out of edits.
+- Keep generated folders (`.next`, `.next-leak-test`, `out`, `coverage`, `node_modules`) out of edits.
 - Future design-system work should align content and layout to the dot-grid/sketchbook direction in `DESIGN.md`.
 
 ## Theme awareness

--- a/VAULT.md
+++ b/VAULT.md
@@ -80,12 +80,13 @@ guarantees the privacy boundary makes, and how to debug when notes don't appear.
 12. **Fine-grained PAT only.** Token scoped to `dy-journal` only with
     `Contents: read` + `Metadata: read`. Classic PATs (with broad `repo` scope)
     are rejected.
-13. **CI leak test.** Every PR is gated by a leak test that walks built
-    artifacts (`.next/server/**`, `.next/static/**/*.{js,map}`,
-    `.next/cache/fetch-cache/**`, `.next/trace`, `_next/data/`, `out/**`,
-    `public/**`) plus HTTP-level checks (request `/sitemap.xml`, `/robots.txt`,
-    `/feed.xml`, `/_next/data/...json`, OG endpoints) for any private fixture
-    string. Includes a positive-control canary so a broken test fails loudly.
+13. **CI leak test.** Every PR is gated by a leak test that builds fixture
+    content into isolated `.next-leak-test/` artifacts and scans its `server/**`,
+    `static/**/*.{js,map}`, `cache/fetch-cache/**`, `trace`, `_next/data/`, plus
+    `out/**` and `public/**`. HTTP-level checks request `/sitemap.xml`,
+    `/robots.txt`, `/feed.xml`, `/_next/data/...json`, and OG endpoints for any
+    private fixture string. A positive-control canary makes a broken test fail
+    loudly without replacing the production `.next` build.
 
 ## Vault layout
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ export default tseslint.config(
     ignores: [
       ".git/**",
       ".next/**",
+      ".next-leak-test/**",
       ".claude/**",
       ".worktrees/**",
       "out/**",

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,14 @@
 /** @type {import('next').NextConfig} */
+const leakTestDistDir = process.env.LEAK_TEST_DIST_DIR?.trim();
+
+if (leakTestDistDir && leakTestDistDir !== ".next-leak-test") {
+  throw new Error("LEAK_TEST_DIST_DIR must be .next-leak-test when set");
+}
+
 const nextConfig = {
+  // The privacy leak gate builds into an isolated directory so running the
+  // test cannot replace the production artifact in `.next`.
+  distDir: leakTestDistDir || ".next",
   reactStrictMode: true,
   turbopack: {
     root: __dirname,

--- a/test/leak.test.ts
+++ b/test/leak.test.ts
@@ -6,7 +6,7 @@
  * HTTP-level gate). This is the load-bearing privacy guarantee.
  *
  * Structure:
- *   Phase 0 — build the site against __fixtures__/vault/
+ *   Phase 0 — build the site against __fixtures__/vault/ in an isolated dist directory
  *   Phase 1 — collect private strings, scan build artifacts
  *   Phase 2 — HTTP-level checks against `next start`
  *
@@ -21,14 +21,18 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execSync, spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
 import {
   readFile,
+  writeFile,
   readdir,
   stat,
   access,
+  rm,
   constants as fsConstants,
 } from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import matter from "gray-matter";
 import { resolveVisibility } from "../lib/vault/fail-closed";
 import { walkVault } from "../lib/vault/walk";
@@ -38,6 +42,38 @@ import { deriveSlug } from "../lib/vault/slug";
 
 const REPO_ROOT = path.resolve(".");
 const FIXTURE_VAULT = path.resolve("__fixtures__/vault");
+const LEAK_BUILD_DIR_NAME = ".next-leak-test";
+const LEAK_BUILD_DIR = path.join(REPO_ROOT, LEAK_BUILD_DIR_NAME);
+
+function leakBuildEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    LEAK_TEST_DIST_DIR: LEAK_BUILD_DIR_NAME,
+    VAULT_PATH: FIXTURE_VAULT,
+    VAULT_SOURCE: "local",
+    NODE_ENV: "production",
+  };
+}
+
+async function readProductionBuildMarkers(): Promise<{
+  buildId: string | null;
+  prerenderManifest: string | null;
+}> {
+  const readOptional = async (relativePath: string): Promise<string | null> => {
+    try {
+      return await readFile(path.join(REPO_ROOT, ".next", relativePath), "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
+  };
+
+  const [buildId, prerenderManifest] = await Promise.all([
+    readOptional("BUILD_ID"),
+    readOptional("prerender-manifest.json"),
+  ]);
+  return { buildId, prerenderManifest };
+}
 
 /**
  * The unique sentinel string from __fixtures__/vault/leak-canary.md.
@@ -70,23 +106,40 @@ let canarySentinelWasChecked = false;
 
 beforeAll(
   async () => {
-    // Run next build against the fixture vault.
-    // This is the same build that ships to Vercel, so artifact leaks here
-    // will be caught before deploy.
-    execSync("npm run build", {
-      env: {
-        ...process.env,
-        VAULT_PATH: FIXTURE_VAULT,
-        VAULT_SOURCE: "local",
-        NODE_ENV: "production",
-      },
-      cwd: REPO_ROOT,
-      stdio: "pipe",
-    });
+    const productionBuildBefore = await readProductionBuildMarkers();
+    const nextEnvPath = path.join(REPO_ROOT, "next-env.d.ts");
+    const nextEnvBefore = await readFile(nextEnvPath, "utf8");
+    await rm(LEAK_BUILD_DIR, { recursive: true, force: true });
 
-    // Extract the build ID from .next/BUILD_ID
+    // Run next build against the fixture vault.
+    // Use a dedicated dist directory so this gate cannot replace a developer
+    // or release candidate build already present in `.next`.
     try {
-      const buildIdFile = path.join(REPO_ROOT, ".next", "BUILD_ID");
+      execSync("npm run build", {
+        env: leakBuildEnv(),
+        cwd: REPO_ROOT,
+        stdio: "pipe",
+      });
+    } finally {
+      // Next rewrites this tracked declaration to point at the custom dist dir.
+      // Restore it even when the fixture build fails.
+      await writeFile(nextEnvPath, nextEnvBefore);
+    }
+
+    const productionBuildAfter = await readProductionBuildMarkers();
+    if (
+      productionBuildAfter.buildId !== productionBuildBefore.buildId ||
+      productionBuildAfter.prerenderManifest !== productionBuildBefore.prerenderManifest
+    ) {
+      throw new Error(
+        "LEAK TEST INFRASTRUCTURE BROKEN: the fixture build modified `.next`. " +
+          "Keep the leak-test build isolated from production artifacts.",
+      );
+    }
+
+    // Extract the build ID from the isolated fixture build.
+    try {
+      const buildIdFile = path.join(LEAK_BUILD_DIR, "BUILD_ID");
       buildId = (await readFile(buildIdFile, "utf8")).trim();
     } catch {
       buildId = "unknown";
@@ -126,6 +179,10 @@ beforeAll(
   // 120s timeout for next build
   120_000,
 );
+
+afterAll(async () => {
+  await rm(LEAK_BUILD_DIR, { recursive: true, force: true });
+});
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -290,7 +347,7 @@ async function collectArtifactFiles(
  * Collects all build artifact files to scan per the spec.
  */
 async function collectArtifactPaths(): Promise<string[]> {
-  const nextDir = path.join(REPO_ROOT, ".next");
+  const nextDir = LEAK_BUILD_DIR;
   const outDir = path.join(REPO_ROOT, "out");
   const vercelDir = path.join(REPO_ROOT, ".vercel", "output");
   const publicDir = path.join(REPO_ROOT, "public");
@@ -652,12 +709,7 @@ describe("Phase 2 — HTTP-level checks (P26)", () => {
         "node_modules/.bin/next",
         ["start", "--port", String(serverPort)],
         {
-          env: {
-            ...process.env,
-            VAULT_PATH: FIXTURE_VAULT,
-            VAULT_SOURCE: "local",
-            NODE_ENV: "production",
-          },
+          env: leakBuildEnv(),
           cwd: REPO_ROOT,
           stdio: "pipe",
         },
@@ -679,9 +731,20 @@ describe("Phase 2 — HTTP-level checks (P26)", () => {
   );
 
   afterAll(async () => {
-    if (serverProcess) {
-      serverProcess.kill("SIGTERM");
-      serverProcess = null;
+    const process = serverProcess;
+    serverProcess = null;
+    if (!process || process.exitCode !== null || process.signalCode !== null) return;
+
+    const exit = once(process, "exit");
+    process.kill("SIGTERM");
+    const exited = await Promise.race([
+      exit.then(() => true),
+      delay(5_000, false, { ref: false }),
+    ]);
+
+    if (!exited && process.exitCode === null && process.signalCode === null) {
+      process.kill("SIGKILL");
+      await exit;
     }
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", ".next", "out", "coverage"]
+  "exclude": ["node_modules", ".next", ".next-leak-test", "out", "coverage"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       "**/node_modules/**",
       "**/dist/**",
       "**/.next/**",
+      "**/.next-leak-test/**",
       "**/.claude/**",
       "**/.worktrees/**",
     ],


### PR DESCRIPTION
## Summary
- build the privacy leak fixture into an isolated `.next-leak-test` directory
- preserve the existing `.next` release artifact and restore Next's generated `next-env.d.ts`
- run artifact/HTTP privacy checks against the same isolated output and cleanly stop the test server
- ignore and document the generated test directory across repository tooling

## Verification
- `npm run leak-test` — 14 passed
- production `.next/BUILD_ID` and prerender manifest unchanged across leak test
- `next-env.d.ts` unchanged across leak test
- `.next-leak-test` removed after completion
- `npm run check` — 354 regular tests + 14 leak tests passed; lint/typecheck/build passed
- model-inverted review: Claude Code 2.1.222 / Opus 5 high; valid cleanup findings applied
- `/simplify` scoped to the exact leak-isolation diff; no additional worthwhile edits