### PR TITLE
chore(rc): enable blog on develop

### DIFF
--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -26,13 +26,13 @@ export const ABOUT_PAGE_ENABLED = false;
 /**
  * `/blog` index + article pages + navigation links.
  *
- * Disabled for the release candidate while the public articles receive their
- * final editorial pass. Flip to `true` once the blog is ready to ship.
+ * Enabled for the Tailnet release candidate so public and preview-visible
+ * articles can be evaluated before the production release.
  *
- * When `false`:
- *   - `pages/blog/index.tsx` returns `notFound` before reading the vault.
- *   - `pages/blog/[slug].tsx` generates no paths and returns `notFound`
- *     before reading the vault or requested slug.
- *   - `components/SiteNav.tsx` omits Blog from desktop and mobile navigation.
+ * When `true`:
+ *   - `/blog` and eligible `/blog/[slug]` routes are generated from the vault.
+ *   - `components/SiteNav.tsx` includes Blog in desktop and mobile navigation.
+ *
+ * Set this back to `false` to fail closed before any vault reads.
  */
-export const BLOG_PAGE_ENABLED = false;
+export const BLOG_PAGE_ENABLED = true;

--- a/test/blog-feature-flag.test.ts
+++ b/test/blog-feature-flag.test.ts
@@ -4,10 +4,12 @@ import type { GetStaticPathsContext, GetStaticPropsContext } from "next";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const vaultMocks = vi.hoisted(() => ({
+  formatEntryNumber: vi.fn((index: number) => String(index).padStart(3, "0")),
   getNoteBySlug: vi.fn(),
   getPublicNotes: vi.fn(),
   getVaultConfig: vi.fn(),
   getVaultTaxonomy: vi.fn(),
+  stableIndexBySlug: vi.fn(() => new Map<string, number>()),
 }));
 
 vi.mock("../lib/vault", () => vaultMocks);
@@ -26,39 +28,46 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vaultMocks.getPublicNotes.mockResolvedValue([]);
+  vaultMocks.getVaultTaxonomy.mockResolvedValue({ tags: {} });
+  vaultMocks.getVaultConfig.mockReturnValue(null);
+  vaultMocks.getNoteBySlug.mockResolvedValue(null);
 });
 
-describe("disabled blog feature flag", () => {
-  test("defaults to false", () => {
-    expect(BLOG_PAGE_ENABLED).toBe(false);
+describe("enabled blog feature flag", () => {
+  test("enables the blog for the release candidate", () => {
+    expect(BLOG_PAGE_ENABLED).toBe(true);
   });
 
-  test("/blog returns notFound before any vault reads", async () => {
+  test("/blog reads the vault and returns an empty public index when unconfigured", async () => {
     const result = await getBlogIndexStaticProps({} as GetStaticPropsContext);
 
-    expect(result).toEqual({ notFound: true });
-    expect(vaultMocks.getPublicNotes).not.toHaveBeenCalled();
-    expect(vaultMocks.getVaultTaxonomy).not.toHaveBeenCalled();
-    expect(vaultMocks.getVaultConfig).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      props: {
+        cards: [],
+        notebookTagFilters: [],
+        vaultConfigured: false,
+      },
+      revalidate: 1800,
+    });
+    expect(vaultMocks.getPublicNotes).toHaveBeenCalledOnce();
+    expect(vaultMocks.getVaultTaxonomy).toHaveBeenCalledOnce();
+    expect(vaultMocks.getVaultConfig).toHaveBeenCalledOnce();
   });
 
-  test("/blog/[slug] generates no paths without reading the vault", async () => {
+  test("/blog/[slug] generates paths from eligible vault notes", async () => {
     const result = await getBlogSlugStaticPaths({} as GetStaticPathsContext);
 
     expect(result).toEqual({ paths: [], fallback: false });
-    expect(vaultMocks.getPublicNotes).not.toHaveBeenCalled();
+    expect(vaultMocks.getPublicNotes).toHaveBeenCalledOnce();
   });
 
-  test("/blog/[slug] returns notFound before reading params or the vault", async () => {
-    const context = Object.defineProperty({}, "params", {
-      get: () => {
-        throw new Error("disabled blog route read params");
-      },
-    }) as GetStaticPropsContext;
+  test("/blog/[slug] reads the requested slug and fails closed when it is missing", async () => {
+    const context = { params: { slug: "missing" } } as GetStaticPropsContext;
 
     const result = await getBlogSlugStaticProps(context);
 
     expect(result).toEqual({ notFound: true });
-    expect(vaultMocks.getNoteBySlug).not.toHaveBeenCalled();
+    expect(vaultMocks.getNoteBySlug).toHaveBeenCalledWith("missing");
   });
 });

--- a/test/site-nav.test.tsx
+++ b/test/site-nav.test.tsx
@@ -11,7 +11,7 @@ import Context from "../components/context";
 import SiteNav from "../components/SiteNav";
 
 describe("SiteNav", () => {
-  test("omits Blog from desktop and mobile navigation without leaving an empty column", () => {
+  test("includes Blog in desktop and mobile navigation with a six-column mobile grid", () => {
     const { container } = render(
       <Context.Provider value={{ theme: "light", toggleTheme: vi.fn() }}>
         <SiteNav current="work" />
@@ -20,14 +20,17 @@ describe("SiteNav", () => {
 
     const desktopNav = container.querySelector(".navTabs");
     expect(desktopNav).not.toBeNull();
-    expect(within(desktopNav as HTMLElement).queryByRole("link", { name: "Blog" })).toBeNull();
+    expect(within(desktopNav as HTMLElement).getByRole("link", { name: "Blog" })).toHaveAttribute(
+      "href",
+      "/blog",
+    );
 
     const mobileNav = container.querySelector('[aria-label="Mobile navigation"]');
     expect(mobileNav).not.toBeNull();
-    expect((mobileNav as HTMLElement).querySelector('a[href="/blog"]')).toBeNull();
-    expect((mobileNav as HTMLElement).querySelectorAll(".mobileNavItem")).toHaveLength(5);
+    expect((mobileNav as HTMLElement).querySelector('a[href="/blog"]')).not.toBeNull();
+    expect((mobileNav as HTMLElement).querySelectorAll(".mobileNavItem")).toHaveLength(6);
     expect(mobileNav as HTMLElement).toHaveStyle({
-      gridTemplateColumns: "repeat(5, minmax(0, 1fr))",
+      gridTemplateColumns: "repeat(6, minmax(0, 1fr))",
     });
 
     expect(within(desktopNav as HTMLElement).getByRole("link", { name: "Work" })).toHaveAttribute(


### PR DESCRIPTION
## Summary
- enable the Blog index, article routes, and navigation on `develop`
- keep the existing fail-closed switch available for rollback
- update feature-flag and navigation coverage for the enabled state

## Verification
- `vitest run test/blog-feature-flag.test.ts test/site-nav.test.tsx` — 7 passed
- `npm run check` — lint/typecheck/build passed; 354 regular tests + 14 leak tests passed
- local-vault preview build generated `/blog` and 8 article routes
- simplify pass removed formatting-only churn from the original checkpoint