### PR TITLE
fix(blog): stop month labels at final card row

### DIFF
--- a/components/PortfolioCardGrid.tsx
+++ b/components/PortfolioCardGrid.tsx
@@ -2,6 +2,10 @@ import Link from "next/link";
 import type { CSSProperties } from "react";
 
 import { gm500, gm800, cp400 } from "../global/fonts";
+import {
+  PORTFOLIO_CARD_CLASS,
+  PORTFOLIO_CARD_GRID_CLASS,
+} from "../lib/portfolio-card-grid-geometry";
 
 export interface PortfolioCardLink {
   href: string;
@@ -264,7 +268,7 @@ const PortfolioCardGrid = ({
   }
 
   return (
-    <div className="portfolioCardGrid" aria-label={ariaLabel}>
+    <div className={PORTFOLIO_CARD_GRID_CLASS} aria-label={ariaLabel}>
       {items.map((item) => {
         const accentInk = item.accentInk ?? contrastInk(item.accent);
         const style: CSSProperties = {
@@ -279,7 +283,7 @@ const PortfolioCardGrid = ({
         }
 
         return (
-          <article className="portfolioCard" key={item.id} style={style}>
+          <article className={PORTFOLIO_CARD_CLASS} key={item.id} style={style}>
             <header className={`portfolioCardTop ${gm500.className}`}>
               <span className="portfolioCardTopLeft">
                 <span>{item.indexLabel}</span>

--- a/lib/portfolio-card-grid-geometry.ts
+++ b/lib/portfolio-card-grid-geometry.ts
@@ -1,0 +1,17 @@
+/**
+ * Class names and geometry for the DOM that `components/PortfolioCardGrid.tsx`
+ * renders. Callers that measure the grid go through here so a rename in the
+ * component is a compile-time break rather than a silent mis-measurement.
+ */
+export const PORTFOLIO_CARD_GRID_CLASS = "portfolioCardGrid";
+export const PORTFOLIO_CARD_CLASS = "portfolioCard";
+
+/** Offset of the grid's final card row from the grid's own top, in pixels. */
+export const getLastGridRowTop = (grid: HTMLElement): number => {
+  const lastCard = grid.querySelector<HTMLElement>(
+    `:scope > .${PORTFOLIO_CARD_CLASS}:last-of-type`,
+  );
+  if (!lastCard) return 0;
+
+  return Math.max(0, lastCard.getBoundingClientRect().top - grid.getBoundingClientRect().top);
+};

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -1,6 +1,6 @@
 import Head from "next/head";
 import dynamic from "next/dynamic";
-import { useContext, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import type { GetStaticProps } from "next";
 
 import Context from "../../components/context";
@@ -11,6 +11,10 @@ import { MarginAnchor } from "../../components/lab/system/MarginAnchor";
 import { gm500, gm800, cp400 } from "../../global/fonts";
 import { dotGridColor } from "../../lib/dot-grid-color";
 import { BLOG_PAGE_ENABLED } from "../../lib/flags";
+import {
+  PORTFOLIO_CARD_GRID_CLASS,
+  getLastGridRowTop,
+} from "../../lib/portfolio-card-grid-geometry";
 import { themeBootstrap } from "../../lib/theme-bootstrap";
 import {
   formatEntryNumber,
@@ -370,6 +374,44 @@ export default function BlogIndex({
   }, [cards, filter]);
 
   const visibleMonths = useMemo(() => groupCardsByMonth(visibleCards), [visibleCards]);
+  const blogMonthsRef = useRef<HTMLDivElement>(null);
+
+  // Measures the desktop sticky track. Below 900px the track is `display:
+  // contents` (see the mobile block below), so the heights written here have no
+  // box to apply to and the effect is inert — the grid observer just never has
+  // anything to correct. The grid's own box is the only signal needed: a column
+  // reflow or any row growing changes the grid height, which is what moves the
+  // final row's top.
+  useEffect(() => {
+    const blogMonths = blogMonthsRef.current;
+    if (!blogMonths || typeof ResizeObserver === "undefined") return;
+
+    const zones = Array.from(
+      blogMonths.querySelectorAll<HTMLElement>(".blogMonthStickyZone"),
+      (zone) => ({
+        track: zone.querySelector<HTMLElement>(":scope > .blogMonthStickyTrack"),
+        grid: zone.querySelector<HTMLElement>(`:scope > .${PORTFOLIO_CARD_GRID_CLASS}`),
+      }),
+    ).filter((zone): zone is { track: HTMLElement; grid: HTMLElement } =>
+      Boolean(zone.track && zone.grid),
+    );
+
+    // Read every grid before writing any height, so one write can't force a
+    // reflow before the next read.
+    const measure = () => {
+      const heights = zones.map(({ grid }) => getLastGridRowTop(grid));
+      zones.forEach(({ track }, index) => {
+        track.style.height = `${heights[index]}px`;
+      });
+    };
+
+    measure();
+
+    const resizeObserver = new ResizeObserver(measure);
+    zones.forEach(({ grid }) => resizeObserver.observe(grid));
+
+    return () => resizeObserver.disconnect();
+  }, [visibleMonths]);
 
   return (
     <>
@@ -447,26 +489,25 @@ export default function BlogIndex({
           </div>
 
           {visibleMonths.length > 0 ? (
-            <div className="blogMonths">
+            <div ref={blogMonthsRef} className="blogMonths">
               {visibleMonths.map((month) => (
                 <section
                   key={month.key}
                   className="blogMonth"
                   aria-labelledby={`blog-month-${month.key}`}
                 >
-                  {/* The grid lives inside the sticky zone so the margin header
-                      stays pinned for exactly as long as its own month's cards
-                      are on screen, then hands off to the next month. */}
                   <div className="blogMonthStickyZone">
-                    <MarginAnchor top={3} className={gm500.className}>
-                      <span className="blogMonthName" id={`blog-month-${month.key}`}>
-                        {month.monthLabel}
-                      </span>
-                      <span className="blogMonthYear">{month.year}</span>
-                      <span className="blogMonthCount">
-                        {month.cards.length} {month.cards.length === 1 ? "entry" : "entries"}
-                      </span>
-                    </MarginAnchor>
+                    <div className="blogMonthStickyTrack">
+                      <MarginAnchor top={3} className={gm500.className}>
+                        <span className="blogMonthName" id={`blog-month-${month.key}`}>
+                          {month.monthLabel}
+                        </span>
+                        <span className="blogMonthYear">{month.year}</span>
+                        <span className="blogMonthCount">
+                          {month.cards.length} {month.cards.length === 1 ? "entry" : "entries"}
+                        </span>
+                      </MarginAnchor>
+                    </div>
 
                     <PortfolioCardGrid
                       ariaLabel={`${month.monthLabel} ${month.year} blog entries`}
@@ -680,9 +721,24 @@ export default function BlogIndex({
         }
         .blogMonthStickyZone {
           position: relative;
-          display: flex;
-          flex-direction: column;
-          gap: var(--u);
+        }
+        /* The zero-height MarginAnchor sticks inside this measured track. Its
+           bottom is the top of the grid's final row, so a one-row month never
+           pins and a longer month hands the label to its final row instead of
+           floating over it.
+           Notebook's MonthBlock gets the same boundary for free by rendering
+           its last authored row outside the sticky zone. That isn't available
+           here: PortfolioCardGrid's rows are implicit and breakpoint-driven, so
+           "all but the final row" isn't knowable at render time — hence the
+           measured height. */
+        .blogMonthStickyTrack {
+          position: absolute;
+          inset: 0 0 auto;
+          height: 0;
+          pointer-events: none;
+        }
+        .blogMonthStickyTrack :global(.marginAnchor) {
+          --margin-anchor-inner-top: 0px;
         }
         /* Anchor markup belongs to MarginAnchor, so reach it globally — but
            only ever from inside .blogMonth, never the homepage notebook. */
@@ -766,7 +822,15 @@ export default function BlogIndex({
             gap: calc(var(--u) * 1.5);
           }
           .blogMonthStickyZone {
+            display: flex;
+            flex-direction: column;
             gap: var(--u);
+          }
+          /* Mobile month strips remain in normal flow. The measured desktop
+             track has no box here, so MarginAnchor keeps using the whole month
+             section as its sticky containing block. */
+          .blogMonthStickyTrack {
+            display: contents;
           }
           /* The gutter is gone on mobile, so the rail becomes a full-bleed
              sticky strip that pins directly under the chip bar and slides

--- a/test/blog-month-sticky.test.ts
+++ b/test/blog-month-sticky.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+
+import { PORTFOLIO_CARD_CLASS, getLastGridRowTop } from "../lib/portfolio-card-grid-geometry";
+
+const rectAt =
+  (top: number) =>
+  (): DOMRect =>
+    ({ top }) as DOMRect;
+
+/** Builds a grid whose top is the first card's top, as a real flow layout would. */
+const makeGrid = (...cardTops: number[]) => {
+  const grid = document.createElement("div");
+  grid.getBoundingClientRect = rectAt(cardTops[0] ?? 0);
+
+  for (const top of cardTops) {
+    const card = document.createElement("article");
+    card.className = PORTFOLIO_CARD_CLASS;
+    card.getBoundingClientRect = rectAt(top);
+    grid.append(card);
+  }
+
+  return grid;
+};
+
+describe("blog month sticky track", () => {
+  test("has no sticky travel when the final card is in the first row", () => {
+    expect(getLastGridRowTop(makeGrid(120))).toBe(0);
+  });
+
+  test("ends the sticky track at the top of the final card row", () => {
+    expect(getLastGridRowTop(makeGrid(120, 660))).toBe(540);
+  });
+
+  test("has no sticky travel for an empty grid", () => {
+    expect(getLastGridRowTop(makeGrid())).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- terminate each desktop month-label sticky track at the top of its final actual card row
- recompute boundaries from rendered grid geometry when filters or responsive layout change
- preserve one-row and mobile normal-flow behavior

## Verification
- `rtk vitest run test/blog-month-sticky.test.ts test/blog-feature-flag.test.ts` — 7 passed
- `rtk npm run check` — passed
- production Chromium geometry QA at 1280x500 and 390x844 — all 8 assertions passed, including pin/release alignment, filter recomputation, and no overflow
- independent `/simplify` review: Claude Code / Anthropic Opus 5 (high effort)