### PR TITLE
Fix blog month header sticky alignment

### DIFF
--- a/lib/blog-month-sticky-geometry.ts
+++ b/lib/blog-month-sticky-geometry.ts
@@ -1,0 +1,7 @@
+/**
+ * ResizeObserver reports fractional CSS pixels, while the sticky ceiling is
+ * represented by a CSS custom property. Round up so the rail never overlaps
+ * the filter bar because of a sub-pixel measurement.
+ */
+export const measuredStickyHeight = (height: number): number =>
+  Number.isFinite(height) ? Math.max(0, Math.ceil(height)) : 0;

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -10,6 +10,7 @@ import PortfolioCardGrid, { type PortfolioCardItem } from "../../components/Port
 import { MarginAnchor } from "../../components/lab/system/MarginAnchor";
 import { gm500, gm800, cp400 } from "../../global/fonts";
 import { dotGridColor } from "../../lib/dot-grid-color";
+import { measuredStickyHeight } from "../../lib/blog-month-sticky-geometry";
 import { BLOG_PAGE_ENABLED } from "../../lib/flags";
 import {
   PORTFOLIO_CARD_GRID_CLASS,
@@ -374,7 +375,30 @@ export default function BlogIndex({
   }, [cards, filter]);
 
   const visibleMonths = useMemo(() => groupCardsByMonth(visibleCards), [visibleCards]);
+  const blogFrameRef = useRef<HTMLElement>(null);
+  const blogFiltersRef = useRef<HTMLDivElement>(null);
   const blogMonthsRef = useRef<HTMLDivElement>(null);
+
+  // The filter bar itself is sticky beneath the nav and can grow when chips
+  // wrap. Keep the desktop month rail's sticky ceiling directly below that
+  // real box (plus its normal-flow bottom gap) rather than assuming one row.
+  useEffect(() => {
+    const blogFrame = blogFrameRef.current;
+    const blogFilters = blogFiltersRef.current;
+    if (!blogFrame || !blogFilters || typeof ResizeObserver === "undefined") return;
+
+    const measure = () => {
+      const height = measuredStickyHeight(blogFilters.getBoundingClientRect().height);
+      blogFrame.style.setProperty("--blog-filter-height", `${height}px`);
+    };
+
+    measure();
+
+    const resizeObserver = new ResizeObserver(measure);
+    resizeObserver.observe(blogFilters);
+
+    return () => resizeObserver.disconnect();
+  }, []);
 
   // Measures the desktop sticky track. Below 900px the track is `display:
   // contents` (see the mobile block below), so the heights written here have no
@@ -428,7 +452,7 @@ export default function BlogIndex({
       <DotGrid color={dotGridColor(theme)} />
 
       <main className="blogPage">
-        <section className="blogFrame">
+        <section ref={blogFrameRef} className="blogFrame">
           <div className="blogIntroBand">
             <header className="blogHead">
               <span className={`blogKicker ${gm500.className}`}>The bullet journal</span>
@@ -440,6 +464,7 @@ export default function BlogIndex({
           </div>
 
           <div
+            ref={blogFiltersRef}
             className={`blogFilters ${gm500.className}`}
             role="group"
             aria-label="Filter blog entries"
@@ -602,6 +627,11 @@ export default function BlogIndex({
           padding-top: 48px;
         }
         .blogFrame {
+          /* One non-wrapping chip row is 62px: 16px vertical padding on both
+             sides, a 29px chip, and the filter's bottom rule. This is the
+             conservative SSR/no-ResizeObserver fallback; hydration replaces
+             it with the bar's measured live height. */
+          --blog-filter-height: calc(2 * var(--u) + 30px);
           position: relative;
           min-height: 100vh;
           padding: 40px var(--content-pad-left) 96px;
@@ -743,6 +773,12 @@ export default function BlogIndex({
         /* Anchor markup belongs to MarginAnchor, so reach it globally — but
            only ever from inside .blogMonth, never the homepage notebook. */
         .blogMonth :global(.marginAnchor) {
+          /* The live filter-bar height is measured on .blogFrame. Its scoped
+             fallback covers the non-wrapping row until hydration, while
+             ResizeObserver handles wrapped desktop chips. */
+          --margin-anchor-top: calc(
+            var(--nav-h, 48px) + var(--blog-filter-height) + 24px
+          );
           --margin-anchor-z-index: 30;
         }
         .blogMonthName {

--- a/test/blog-month-grouping.test.tsx
+++ b/test/blog-month-grouping.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("next/font/google", () => ({
   Geist_Mono: () => ({ className: "geist-mono" }),
@@ -64,6 +64,8 @@ const readIndexLabels = (container: HTMLElement) =>
   [...container.querySelectorAll(".portfolioCardTopLeft span:first-child")].map(
     (span) => span.textContent,
   );
+
+afterEach(() => vi.unstubAllGlobals());
 
 describe("blog index month grouping", () => {
   test("groups cards into newest-first month blocks with margin-rail headers", () => {
@@ -154,6 +156,40 @@ describe("blog index month grouping", () => {
     const filters = container.querySelector(".blogFilters");
     expect(filters?.parentElement).toBe(frame);
     expect(container.querySelector(".blogFilters .blogFiltersInner .blogChip")).not.toBeNull();
+  });
+
+  test("measures the filter bar into the month rail's scoped sticky geometry", () => {
+    class ResizeObserverMock {
+      static instances: ResizeObserverMock[] = [];
+      readonly observed: Element[] = [];
+
+      constructor(readonly callback: ResizeObserverCallback) {
+        ResizeObserverMock.instances.push(this);
+      }
+
+      observe(element: Element) {
+        this.observed.push(element);
+      }
+
+      disconnect() {}
+    }
+
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    const { container } = renderIndex();
+    const frame = container.querySelector<HTMLElement>(".blogFrame");
+    const filters = container.querySelector<HTMLElement>(".blogFilters");
+    const observer = ResizeObserverMock.instances.find((instance) =>
+      instance.observed.includes(filters!),
+    );
+
+    expect(frame).not.toBeNull();
+    expect(filters).not.toBeNull();
+    expect(observer).toBeDefined();
+
+    filters!.getBoundingClientRect = () => ({ height: 117.2 }) as DOMRect;
+    observer!.callback([], observer! as unknown as ResizeObserver);
+
+    expect(frame!.style.getPropertyValue("--blog-filter-height")).toBe("118px");
   });
 
   test("falls back to the empty state when a filter matches nothing", () => {

--- a/test/blog-month-sticky.test.ts
+++ b/test/blog-month-sticky.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 
+import { measuredStickyHeight } from "../lib/blog-month-sticky-geometry";
 import { PORTFOLIO_CARD_CLASS, getLastGridRowTop } from "../lib/portfolio-card-grid-geometry";
 
 const rectAt =
@@ -23,6 +24,13 @@ const makeGrid = (...cardTops: number[]) => {
 };
 
 describe("blog month sticky track", () => {
+  test("rounds a measured filter height up so the sticky rail cannot overlap it", () => {
+    expect(measuredStickyHeight(57.1)).toBe(58);
+    expect(measuredStickyHeight(57)).toBe(57);
+    expect(measuredStickyHeight(-1)).toBe(0);
+    expect(measuredStickyHeight(Number.NaN)).toBe(0);
+  });
+
   test("has no sticky travel when the final card is in the first row", () => {
     expect(getLastGridRowTop(makeGrid(120))).toBe(0);
   });


### PR DESCRIPTION
## Summary

- measure the real sticky filter-bar height so desktop month labels pin below it
- preserve the existing 24px card-row gap and mobile sticky behavior
- cover fractional measurements and ResizeObserver wiring with regressions

## Root cause

The month rail used `MarginAnchor top={3}`, which pinned it at 48px—the filter bar’s own sticky top—instead of below the filter bar. The filter bar can wrap, so a fixed offset would regress at narrower desktop widths.

## Validation

- `npm run check` — passed: lint (11 existing warnings), typecheck, 359 tests, production build, 14 leak tests
- Chromium 1156×1382: initial APR/card top both 926.75px; sticky filter bottom 110px and APR top 134px (24px gap)
- adversarial exact-diff review: no P0/P1/P2 findings
- `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Blog month navigation now accounts for the live height of the sticky filter bar.
  - Improved positioning when filter chips wrap across multiple lines and on mobile layouts.

- **Bug Fixes**
  - Sticky month anchors now handle fractional, negative, or invalid height measurements reliably.

- **Tests**
  - Added coverage for dynamic filter-bar sizing and sticky navigation positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->